### PR TITLE
 update screen width calculation in ImagePager for accurate layout

### DIFF
--- a/presentation/onboarding/src/main/java/com/giraffe/onboarding/ImagePager.kt
+++ b/presentation/onboarding/src/main/java/com/giraffe/onboarding/ImagePager.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
@@ -39,7 +39,7 @@ fun ImagePager(
     images: List<Int>
 ) {
     val layoutDirection = LocalLayoutDirection.current
-    val screenWidthDp = LocalWindowInfo.current.containerSize.width.dp
+    val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
     val horizontalPadding = screenWidthDp * 0.1f
 
 


### PR DESCRIPTION
ImagePager component needed to calculate horizontal padding based on screen width.
Using LocalWindowInfo.current.containerSize in practice, it returned 0 in some cases


https://github.com/user-attachments/assets/cd6624c2-a715-4b5e-bb89-82fe1f1ac1ae


https://github.com/user-attachments/assets/16260257-046f-42d8-aa19-373bf28cb238

