### PR TITLE
fix: prepend base URL to image paths and update image scaling

### DIFF
--- a/designsystem/src/main/java/com/giraffe/designsystem/composable/PosterItemVertically.kt
+++ b/designsystem/src/main/java/com/giraffe/designsystem/composable/PosterItemVertically.kt
@@ -36,10 +36,13 @@ fun PosterItemVertically(
     modifier: Modifier = Modifier,
     onClickPoster: () -> Unit = {}
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
 
         Box(
-            modifier = modifier
+            modifier = Modifier
                 .clip(RoundedCornerShape(Theme.radius.lg))
                 .background(Theme.color.background.card)
                 .aspectRatio(0.74f),

--- a/presentation/details/src/main/java/com/giraffe/details/components/MainDetails.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/components/MainDetails.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -89,8 +90,9 @@ fun MainDetails(
                         bottomEnd = Theme.radius.xl
                     )
                     SafeIslamicImage(
-                        imageUrl = actorImageUrl,
+                        imageUrl = it,
                         contentDescription = actorName,
+                        contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .sharedElement(
                                 sharedContentState = rememberSharedContentState(key = actorImageUrl + key),
@@ -236,6 +238,7 @@ fun MainDetailsHeader(
                     SafeIslamicImage(
                         imageUrl = it,
                         contentDescription = actorName,
+                        contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .sharedElement(
                                 sharedContentState = rememberSharedContentState(key = actorImageUrl + key),

--- a/presentation/details/src/main/java/com/giraffe/details/components/gallery/GalleryItem.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/components/gallery/GalleryItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,7 @@ fun GalleryItem(
     SafeIslamicImage(
         imageUrl = imageUrl.orEmpty(),
         contentDescription = imageUrl.orEmpty(),
+        contentScale = ContentScale.Crop,
         modifier = modifier
             .clip(RoundedCornerShape(Theme.radius.lg))
     ) {

--- a/repository/media/src/main/java/com/giraffe/media/person/PersonRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/person/PersonRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.giraffe.media.person.mapper.toEntity
 import com.giraffe.media.person.mapper.toImageList
 import com.giraffe.media.person.mapper.toTvCredits
 import com.giraffe.media.person.repository.PersonRepository
+import com.giraffe.media.utils.BASE_IMAGE_URL
 import com.giraffe.media.utils.ContentType
 import com.giraffe.media.utils.SafeCall
 import kotlinx.coroutines.Dispatchers
@@ -89,7 +90,11 @@ class PersonRepositoryImpl(
             Person(
                 id = personId,
                 name = details.await().name,
+                imageUrl = BASE_IMAGE_URL + details.await().profilePath,
                 role = details.await().knownForDepartment,
+                birthday = details.await().birthday,
+                placeOfBirth = details.await().placeOfBirth,
+                biography = details.await().biography,
                 images = images.await().toImageList(),
                 movieCredits = movies.await().toEntity(),
                 tvCredits = shows.await().toTvCredits()

--- a/repository/media/src/main/java/com/giraffe/media/person/mapper/Mapper.kt
+++ b/repository/media/src/main/java/com/giraffe/media/person/mapper/Mapper.kt
@@ -53,7 +53,7 @@ fun CrewDto.toEntity(type: PersonType): Person = Person(
 )
 
 fun PersonProfileImageDto.toImageList(): List<String> {
-    return profiles.map { it.filePath }
+    return profiles.map { BASE_IMAGE_URL + it.filePath }
 }
 
 fun List<PersonMovieCastItemDto>.toEntity(): List<PersonCredit> {
@@ -61,7 +61,7 @@ fun List<PersonMovieCastItemDto>.toEntity(): List<PersonCredit> {
         PersonCredit(
             id = it.id,
             title = it.title,
-            posterPath = it.posterPath,
+            posterPath = BASE_IMAGE_URL + it.posterPath,
             voteAverage = it.voteAverage
         )
     }
@@ -72,7 +72,7 @@ fun List<PersonTvCastDto>.toTvCredits(): List<PersonCredit> {
         PersonCredit(
             id = it.id,
             title = it.name,
-            posterPath = it.posterPath,
+            posterPath = BASE_IMAGE_URL + it.posterPath,
             voteAverage = it.voteAverage
         )
     }

--- a/repository/media/src/main/java/com/giraffe/media/utils/ImageUrl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/utils/ImageUrl.kt
@@ -1,3 +1,3 @@
 package com.giraffe.media.utils
 
-const val BASE_IMAGE_URL = "http://image.tmdb.org/t/p/w500"
+const val BASE_IMAGE_URL = "https://image.tmdb.org/t/p/w500"


### PR DESCRIPTION
- Prepending `BASE_IMAGE_URL` to various image paths in the `PersonRepositoryImpl` and `Mapper.kt` files.
- Changing `BASE_IMAGE_URL` from HTTP to HTTPS in `ImageUrl.kt`.
- Setting `ContentScale.Crop` for images in `GalleryItem.kt` and `MainDetails.kt` to ensure they are displayed correctly within their bounds.

<img width="333" height="692" alt="image" src="https://github.com/user-attachments/assets/4542e0c9-b9f9-463a-bb90-68a8c279d815" />
