### PR TITLE
Make `StarCastSection` visibility dependent on `castList`

### DIFF
--- a/presentation/details/src/main/java/com/giraffe/details/components/StarCastSection.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/components/StarCastSection.kt
@@ -1,5 +1,6 @@
 package com.giraffe.details.components
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -38,32 +39,33 @@ fun StarCastSection(
 ) {
     val sizeOfChunkedList = if (castList.size > 2) 2 else 1
     val chunkedList = castList.chunked(sizeOfChunkedList)
-
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-
-        Text(
-            text = title,
-            color = Theme.color.shade.primary,
-            style = Theme.textStyle.title.sm,
-            modifier = Modifier.padding(start = 16.dp),
-        )
-
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+    AnimatedVisibility(castList.isNotEmpty()) {
+        Column(
+            modifier = modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            items(chunkedList) { pair ->
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    pair.forEach { cast ->
-                        CastCard(
-                            actorName = cast.name,
-                            character = cast.role,
-                            actorImage = cast.urlImage.toString(),
-                            modifier = Modifier.clickable(onClick = { onCastClick(cast.id) })
-                        )
+
+            Text(
+                text = title,
+                color = Theme.color.shade.primary,
+                style = Theme.textStyle.title.sm,
+                modifier = Modifier.padding(start = 16.dp),
+            )
+
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(chunkedList) { pair ->
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        pair.forEach { cast ->
+                            CastCard(
+                                actorName = cast.name,
+                                character = cast.role,
+                                actorImage = cast.urlImage.toString(),
+                                modifier = Modifier.clickable(onClick = { onCastClick(cast.id) })
+                            )
+                        }
                     }
                 }
             }

--- a/presentation/details/src/main/java/com/giraffe/details/screens/seriesdetails/screen/SeriesDetailsContent.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/screens/seriesdetails/screen/SeriesDetailsContent.kt
@@ -108,13 +108,11 @@ fun SeriesDetailsContent(
                 }
             }
 
-            AnimatedVisibility(state.cast.isNotEmpty()) {
-                StarCastSection(
-                    title = stringResource(R.string.star_cast),
-                    castList = state.cast,
-                    onCastClick = interaction::navigateToCastDetailsScreen
-                )
-            }
+            StarCastSection(
+                title = stringResource(R.string.star_cast),
+                castList = state.cast,
+                onCastClick = interaction::navigateToCastDetailsScreen
+            )
 
             AnimatedVisibility(state.crew.isNotEmpty()) {
                 StaffInfoSection(


### PR DESCRIPTION
- Removed the redundant `AnimatedVisibility` wrapper around `StarCastSection` in `SeriesDetailsContent` as this logic is now handled within `StarCastSection` itself.