### PR TITLE
Fix: Clears focus when login button is clicked in LoginForm

### DIFF
--- a/presentation/authentication/src/main/java/com/giraffe/authentication/composable/LoginForm.kt
+++ b/presentation/authentication/src/main/java/com/giraffe/authentication/composable/LoginForm.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -22,18 +23,18 @@ fun LoginForm(
     modifier: Modifier = Modifier,
     state: LoginScreenState,
     interaction: LoginInteractionListener
-){
+) {
     val context = LocalContext.current
-
-    Column (
+    val focusManager = LocalFocusManager.current
+    Column(
         modifier = modifier.padding(horizontal = 16.dp)
-    ){
+    ) {
         DefaultTextField(
             startIcon = painterResource(Theme.icons.outline.user),
             placeholder = stringResource(R.string.enter_your_username),
             value = state.username,
             onValueChange = interaction::onUsernameChanged,
-            errorMessage = state.usernameErrorMessage?.let { context.getString(it) } ,
+            errorMessage = state.usernameErrorMessage?.let { context.getString(it) },
             label = stringResource(R.string.username),
             maxLines = 1,
             isPassword = false,
@@ -59,7 +60,10 @@ fun LoginForm(
             text = stringResource(R.string.login),
             enabled = true,
             isLoading = state.isLoadingLogin,
-            onClick = interaction::onLoginClick,
+            onClick = {
+                focusManager.clearFocus()
+                interaction.onLoginClick()
+            },
         )
 
         SecondaryButton(

--- a/presentation/authentication/src/main/java/com/giraffe/authentication/screen/LoginScreen.kt
+++ b/presentation/authentication/src/main/java/com/giraffe/authentication/screen/LoginScreen.kt
@@ -1,11 +1,9 @@
 package com.giraffe.authentication.screen
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -17,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.giraffe.authentication.R
 import com.giraffe.authentication.composable.LoginForm


### PR DESCRIPTION
This change ensures that the keyboard is dismissed when the user
taps the login button.