### PR TITLE
Refactor SeriesDetailsContent to use LazyColumn with sticky header

### DIFF
--- a/presentation/details/src/main/java/com/giraffe/details/screens/seriesdetails/screen/SeriesDetailsContent.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/screens/seriesdetails/screen/SeriesDetailsContent.kt
@@ -1,15 +1,29 @@
 package com.giraffe.details.screens.seriesdetails.screen
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.giraffe.designsystem.composable.AppBar
@@ -18,6 +32,7 @@ import com.giraffe.designsystem.composable.InfoSection
 import com.giraffe.designsystem.composable.PosterListSection
 import com.giraffe.designsystem.composable.SectionTitle
 import com.giraffe.designsystem.composable.button_type.PrimaryButton
+import com.giraffe.designsystem.theme.Theme
 import com.giraffe.details.R
 import com.giraffe.details.components.AddToCollectionContent
 import com.giraffe.details.components.MainMovieOrSeriesDetailsAnimatedContent
@@ -39,137 +54,171 @@ fun SeriesDetailsContent(
     onBackButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scrollState = rememberScrollState()
-    Column(modifier = modifier) {
-
-        // Header
-        Column(Modifier.padding(horizontal = 16.dp)) {
-            AppBar(
-                showBackButton = true,
-                onBackButtonClick = onBackButtonClick
-            )
-            MainMovieOrSeriesDetailsAnimatedContent(
-                type = TypeOfScreen.SERIES.name,
-                name = state.seriesDetails.name,
-                rating = state.seriesDetails.rating,
-                imageUrl = state.seriesDetails.posterUrl,
-                genres = state.genres,
-                releaseYear = state.seriesDetails.releaseYear,
-                onClickAdd = interaction::onClickAddToCollection,
-                onClickPlay = {},
-                isScrolled = scrollState.value > 0,
-                durationAnimation = 2000
-            )
+    var isScrollingUp by remember { mutableStateOf(false) }
+    val scrollState = rememberLazyListState()
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                isScrollingUp = available.y < 0 || scrollState.firstVisibleItemScrollOffset > 0
+                return Offset.Zero
+            }
         }
+    }
 
-        // Scrolling Body
-        Column(
-            modifier = Modifier
-                .padding(top = 24.dp)
-                .verticalScroll(scrollState),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(Theme.color.background.screen)
+            .systemBarsPadding()
+            .pointerInput(Unit) {
+                detectVerticalDragGestures { _, dragAmount ->
+                    isScrollingUp = dragAmount < 0 || scrollState.firstVisibleItemScrollOffset > 0
+                }
+            },
+    ) {
+        AppBar(
+            showBackButton = true,
+            onBackButtonClick = onBackButtonClick,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+
+        LazyColumn(
+            state = scrollState,
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.nestedScroll(nestedScrollConnection),
         ) {
-            InfoSection(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                title = stringResource(R.string.storyline),
-                description = state.seriesDetails.overview
-            )
-
-            AnimatedVisibility(state.seasons.isNotEmpty()) {
+            stickyHeader {
+                Box(
+                    modifier = modifier
+                        .background(Theme.color.background.screen)
+                ) {
+                    MainMovieOrSeriesDetailsAnimatedContent(
+                        type = TypeOfScreen.SERIES.name,
+                        name = state.seriesDetails.name,
+                        rating = state.seriesDetails.rating,
+                        imageUrl = state.seriesDetails.posterUrl,
+                        genres = state.genres,
+                        duration = "${state.seasons.size} ${stringResource(R.string.seasons)}",
+                        releaseYear = state.seriesDetails.releaseYear,
+                        onClickAdd = interaction::onClickAddToCollection,
+                        onClickPlay = {},
+                        isScrolled = isScrollingUp,
+                        durationAnimation = 400,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            }
+            item {
+                InfoSection(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    title = stringResource(R.string.storyline),
+                    description = state.seriesDetails.overview
+                )
+            }
+            item {
                 SectionTitle(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     title = stringResource(R.string.latest_seasons),
-                    clickableText = stringResource(R.string.show_more),
+                    clickableText = if (state.seasons.size > 3) stringResource(R.string.show_more) else null,
                     onClickableText = { interaction.navigateToSeasonsScreen(state.seriesDetails.id) }
                 )
             }
-            AnimatedVisibility(state.seasons.isNotEmpty()) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    for (i in 0..min(2, state.seasons.size - 1)) {
-                        SeasonCard(
-                            posterUrl = state.seasons[i].posterUrl,
-                            title = stringResource(
-                                R.string.season,
-                                state.seasons[i].seasonNumber + 1
-                            ),
-                            overview = state.seasons[i].overview,
-                            rating = state.seasons[i].rating,
-                            episodes = state.seasons[i].episodeCount,
-                            year = state.seasons[i].releaseYear
-                                .takeIf { it.isNotBlank() && it.contains("-") }
-                                ?.split("-")
-                                ?.firstOrNull()
-                                ?.toIntOrNull()
-                        )
+            item {
+                AnimatedVisibility(state.seasons.isNotEmpty()) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        for (i in 0..min(2, state.seasons.size - 1)) {
+                            SeasonCard(
+                                posterUrl = state.seasons[i].posterUrl,
+                                title = stringResource(
+                                    R.string.season,
+                                    state.seasons[i].seasonNumber + 1
+                                ),
+                                overview = state.seasons[i].overview,
+                                rating = state.seasons[i].rating,
+                                episodes = state.seasons[i].episodeCount,
+                                year = state.seasons[i].releaseYear
+                                    .takeIf { it.isNotBlank() && it.contains("-") }
+                                    ?.split("-")
+                                    ?.firstOrNull()
+                                    ?.toIntOrNull()
+                            )
+                        }
                     }
                 }
             }
-
-            StarCastSection(
-                title = stringResource(R.string.star_cast),
-                castList = state.cast,
-                onCastClick = interaction::navigateToCastDetailsScreen
-            )
-
-            StaffInfoSection(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                title = stringResource(R.string.behind_the_scenes),
-                staffList = state.crew
-            )
-
-            AnimatedVisibility(state.recommendedSeries.isNotEmpty()) {
-                PosterListSection(
-                    title = stringResource(R.string.you_might_also_like),
-                    endText = stringResource(R.string.show_more),
-                    posters = state.recommendedSeries,
-                    onClickEndText = {
-                        interaction.navigateToRecommendedSeriesScreen(
-                            seriesId = state.seriesDetails.id,
-                            title = state.seriesDetails.name
-                        )
-                    },
-                    onClickPoster = {
-                        interaction.navigateToSeriesDetails(it.id)
-                    }
+            item {
+                StarCastSection(
+                    title = stringResource(R.string.star_cast),
+                    castList = state.cast,
+                    onCastClick = interaction::navigateToCastDetailsScreen
                 )
             }
-
-            RatingSection(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                onClickCard = interaction::onClickGiveStars
-            )
-
-            AnimatedVisibility(state.seriesReviews.isNotEmpty()) {
-                SectionTitle(
+            item {
+                StaffInfoSection(
                     modifier = Modifier.padding(horizontal = 16.dp),
-                    title = stringResource(R.string.top_reviews),
-                    clickableText = stringResource(R.string.show_more),
+                    title = stringResource(R.string.behind_the_scenes),
+                    staffList = state.crew
                 )
-
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    for (index in 0..min(2, state.seriesReviews.size - 1)) {
-                        val review = state.seriesReviews[index]
-                        val padding = when (index) {
-                            0 -> Modifier.padding(vertical = 12.dp, horizontal = 16.dp)
-                            1 -> Modifier.padding(horizontal = 16.dp)
-                            2 -> Modifier.padding(top = 12.dp, start = 16.dp, end = 16.dp)
-                            else -> Modifier
+            }
+            item {
+                AnimatedVisibility(state.recommendedSeries.isNotEmpty()) {
+                    PosterListSection(
+                        title = stringResource(R.string.you_might_also_like),
+                        endText = stringResource(R.string.show_more),
+                        posters = state.recommendedSeries,
+                        onClickEndText = {
+                            interaction.navigateToRecommendedSeriesScreen(
+                                seriesId = state.seriesDetails.id,
+                                title = state.seriesDetails.name
+                            )
+                        },
+                        onClickPoster = {
+                            interaction.navigateToSeriesDetails(it.id)
                         }
-                        ReviewCard(
-                            modifier = padding,
-                            rate = review.rating.toInt(),
-                            reviewText = review.content,
-                            reviewDate = review.createdAt,
-                            reviewerImageUrl = review.authorImageUrl,
-                            reviewerName = review.authorName,
-                            reviewerUsername = review.authorUserName
-                        )
+                    )
+                }
+            }
+            item {
+                RatingSection(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    onClickCard = interaction::onClickGiveStars
+                )
+            }
+            item {
+                AnimatedVisibility(state.seriesReviews.isNotEmpty()) {
+                    SectionTitle(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        title = stringResource(R.string.top_reviews),
+                        clickableText = stringResource(R.string.show_more),
+                    )
+
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        for (index in 0..min(2, state.seriesReviews.size - 1)) {
+                            val review = state.seriesReviews[index]
+                            val padding = when (index) {
+                                0 -> Modifier.padding(vertical = 12.dp, horizontal = 16.dp)
+                                1 -> Modifier.padding(horizontal = 16.dp)
+                                2 -> Modifier.padding(top = 12.dp, start = 16.dp, end = 16.dp)
+                                else -> Modifier
+                            }
+                            ReviewCard(
+                                modifier = padding,
+                                rate = review.rating,
+                                reviewText = review.content,
+                                reviewDate = review.createdAt,
+                                reviewerImageUrl = review.authorImageUrl,
+                                reviewerName = review.authorName,
+                                reviewerUsername = review.authorUserName
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This commit refactors the `SeriesDetailsContent` composable to use a `LazyColumn` for its main content, with the `MainMovieOrSeriesDetailsAnimatedContent` acting as a sticky header.

Key changes:
- Replaced `Column` with `verticalScroll` with a `LazyColumn`.
- Implemented a sticky header for the main series details using `LazyColumn`'s `stickyHeader` feature.
- Updated scroll detection to use `NestedScrollConnection` and `pointerInput` with `detectVerticalDragGestures` to determine if the user is scrolling up.
- The `isScrolled` state for the `MainMovieOrSeriesDetailsAnimatedContent` is now derived from this improved scroll detection.
- Adjusted padding and layout to accommodate the `LazyColumn` structure.
- Updated `duration` in `MainMovieOrSeriesDetailsAnimatedContent` to display the number of seasons.
- Ensured "Show more" for seasons is only visible if there are more than 3 seasons.
- Corrected the type of `rate` in `ReviewCard` from `Int` to `Double`.