### PR TITLE
Apply min height constraint to season card poster

### DIFF
--- a/presentation/details/src/main/java/com/giraffe/details/components/SeasonCard.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/components/SeasonCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -71,12 +72,12 @@ fun SeasonCard(
                     .fillMaxWidth()
                     .height(intrinsicSize = IntrinsicSize.Min),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically
             ) {
 
                 Box(
                     modifier = Modifier
                         .width(posterWidth)
+                        .heightIn(min = 71.dp)
                         .fillMaxHeight()
                         .clip(
                             RoundedCornerShape(


### PR DESCRIPTION
The season card poster will now have a minimum height of 71.dp. This ensures that even if the image loaded is smaller, the layout maintains a consistent minimum height for the poster area.

![WhatsApp Image 2025-07-29 at 16 50 30_95c5be07](https://github.com/user-attachments/assets/daf9d884-2336-41ee-b96c-557459d5cc35)