### PR TITLE
Refactor recently viewed movies to use Flow

### DIFF
--- a/datasource/local/media/src/main/java/com/giraffe/media/movie/MovieLocalDataSourceImp.kt
+++ b/datasource/local/media/src/main/java/com/giraffe/media/movie/MovieLocalDataSourceImp.kt
@@ -5,6 +5,7 @@ import com.giraffe.media.movie.datasource.local.MoviesLocalDataSource
 import com.giraffe.media.movie.datasource.local.cacheDto.MovieCacheDto
 import com.giraffe.media.movie.datasource.local.cacheDto.MovieGenreCacheDto
 import com.giraffe.media.util.safeCall
+import com.giraffe.media.util.safeFlow
 
 
 class MovieLocalDataSourceImp(
@@ -60,7 +61,7 @@ class MovieLocalDataSourceImp(
         movieDao.clearRecentlyMovies()
     }
 
-    override suspend fun getRecentlyMovies(): List<MovieCacheDto> = safeCall {
+    override fun getRecentlyMovies() = safeFlow {
         movieDao.getRecentlyMovies()
     }
 

--- a/datasource/local/media/src/main/java/com/giraffe/media/movie/dao/MovieDao.kt
+++ b/datasource/local/media/src/main/java/com/giraffe/media/movie/dao/MovieDao.kt
@@ -9,6 +9,7 @@ import com.giraffe.media.movie.datasource.local.cacheDto.MovieCacheDto
 import com.giraffe.media.movie.datasource.local.cacheDto.MovieGenreCacheDto
 import com.giraffe.media.utils.DatabaseConstants.MOVIE_GENRE_TABLE
 import com.giraffe.media.utils.DatabaseConstants.MOVIE_TABLE
+import kotlinx.coroutines.flow.Flow
 
 
 @Dao
@@ -51,7 +52,7 @@ interface MovieDao {
     suspend fun clearRecentlyMovies()
 
     @Query("SELECT * FROM $MOVIE_TABLE WHERE isRecent = 1")
-    suspend fun getRecentlyMovies(): List<MovieCacheDto>
+    fun getRecentlyMovies(): Flow<List<MovieCacheDto>>
 
     @Upsert
     suspend fun updateMovie(movie: MovieCacheDto)

--- a/domain/media/src/main/java/com/giraffe/media/movies/repository/MoviesRepository.kt
+++ b/domain/media/src/main/java/com/giraffe/media/movies/repository/MoviesRepository.kt
@@ -3,6 +3,7 @@ package com.giraffe.media.movies.repository
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.entity.Review
 import com.giraffe.media.movies.entity.Movie
+import kotlinx.coroutines.flow.Flow
 
 interface MoviesRepository {
 
@@ -25,7 +26,7 @@ interface MoviesRepository {
 
     suspend fun clearCache()
 
-    suspend fun getRecentlyMovies(): List<Movie>
+    fun getRecentlyMovies(): Flow<List<Movie>>
 
     suspend fun clearRecentlyMovies()
 

--- a/domain/media/src/main/java/com/giraffe/media/movies/usecase/GetRecentlyMoviesUseCase.kt
+++ b/domain/media/src/main/java/com/giraffe/media/movies/usecase/GetRecentlyMoviesUseCase.kt
@@ -2,11 +2,12 @@ package com.giraffe.media.movies.usecase
 
 import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.repository.MoviesRepository
+import kotlinx.coroutines.flow.Flow
 
 class GetRecentlyMoviesUseCase(
     private val repository: MoviesRepository
 ) {
-    suspend operator fun invoke(): List<Movie> {
+    operator fun invoke(): Flow<List<Movie>> {
         return repository.getRecentlyMovies()
     }
 }

--- a/domain/media/src/test/kotlin/com/giraffe/media/movies/usecase/GetRecentlyMoviesUseCaseTest.kt
+++ b/domain/media/src/test/kotlin/com/giraffe/media/movies/usecase/GetRecentlyMoviesUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.BeforeEach
@@ -23,28 +24,32 @@ class GetRecentlyMoviesUseCaseTest {
 
     @Test
     fun `should returns recently watched movies`() = runTest {
-        val expectedMovies = listOf(
-            Movie(
-                id = 1,
-                title = "Action Movie 1",
-                description = "Explosions and car chases",
-                rating = 7.8f,
-                duration = 120,
-                posterUrl = "https://example.com/action1.jpg",
-                genresID = listOf(28),
-                releaseYear = LocalDate(2020, 6, 15)
-            ),
-            Movie(
-                id = 2,
-                title = "Action Movie 2",
-                description = "More explosions",
-                rating = 8.1f,
-                duration = 110,
-                posterUrl = "https://example.com/action2.jpg",
-                genresID = listOf(28),
-                releaseYear = LocalDate(2021, 9, 5)
+        val expectedMovies = flow {
+            emit(
+                listOf(
+                    Movie(
+                        id = 1,
+                        title = "Action Movie 1",
+                        description = "Explosions and car chases",
+                        rating = 7.8f,
+                        duration = 120,
+                        posterUrl = "https://example.com/action1.jpg",
+                        genresID = listOf(28),
+                        releaseYear = LocalDate(2020, 6, 15)
+                    ),
+                    Movie(
+                        id = 2,
+                        title = "Action Movie 2",
+                        description = "More explosions",
+                        rating = 8.1f,
+                        duration = 110,
+                        posterUrl = "https://example.com/action2.jpg",
+                        genresID = listOf(28),
+                        releaseYear = LocalDate(2021, 9, 5)
+                    )
+                )
             )
-        )
+        }
 
         coEvery { repository.getRecentlyMovies() } returns expectedMovies
 

--- a/presentation/explore/src/main/java/com/giraffe/explore/screen/search/SearchViewModel.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/screen/search/SearchViewModel.kt
@@ -6,6 +6,7 @@ import com.giraffe.media.explore.usecase.ClearSearchHistoryUseCase
 import com.giraffe.media.explore.usecase.DeleteKeywordUseCase
 import com.giraffe.media.explore.usecase.GetSearchKeywordsUseCase
 import com.giraffe.media.explore.usecase.InsertSearchKeywordUseCase
+import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.usecase.ClearRecentlyMoviesUseCase
 import com.giraffe.media.movies.usecase.GetRecentlyMoviesUseCase
 import com.giraffe.media.person.usecase.ClearRecentPeopleUseCase
@@ -13,7 +14,6 @@ import com.giraffe.media.person.usecase.GetRecentPeopleUseCase
 import com.giraffe.media.series.usecase.ClearRecentSeriesUseCase
 import com.giraffe.media.series.usecase.GetRecentSeriesUseCase
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.joinAll
@@ -38,11 +38,9 @@ class SearchViewModel(
 
     override fun getRecentViewedPoster() {
         safeExecute {
-            val recentMovies = async { getRecentlyMoviesUseCase().map { it.toPoster() } }
-            val recentSeries = async { getRecentSeriesUseCase().map { it.toPoster() } }
-            val recentPeople = async { getRecentPeopleUseCase().map { it.toPoster() } }
-            val recentPosters = recentMovies.await() + recentSeries.await() + recentPeople.await()
-            updateState { it.copy(recentPosters = recentPosters) }
+            getRecentlyMoviesUseCase().collectLatest { movies->
+                updateState { it.copy(recentPosters = movies.map(Movie::toPoster)) }
+            }
         }
     }
 

--- a/presentation/home/src/main/java/com/giraffe/home/screen/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/giraffe/home/screen/home/HomeViewModel.kt
@@ -11,9 +11,11 @@ import com.giraffe.media.exception.MediaException
 import com.giraffe.media.exception.NotFoundException
 import com.giraffe.media.exception.UnknownException
 import com.giraffe.media.exception.ValidationException
+import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.usecase.GetMovieGenresUseCase
 import com.giraffe.media.movies.usecase.GetPopularityMoviesUseCase
 import com.giraffe.media.movies.usecase.GetRecentlyMoviesUseCase
+import com.giraffe.media.movies.usecase.GetRecentlyReleasedMoviesUseCase
 import com.giraffe.media.movies.usecase.GetRecommendedMovieUseCase
 import com.giraffe.media.movies.usecase.GetUpcomingMoviesUseCase
 import com.giraffe.media.series.usecase.GetPopularitySeriesUseCase
@@ -24,12 +26,13 @@ import com.giraffe.media.series.usecase.GetSeriesGenresByIdsUseCase
 import com.giraffe.media.series.usecase.GetTopRatedSeriesUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class HomeViewModel(
     private val getPopularityMoviesUseCase: GetPopularityMoviesUseCase,
     private val getPopularitySeriesUseCase: GetPopularitySeriesUseCase,
-    private val getRecentlyReleasedMoviesUseCase: GetRecentlyMoviesUseCase,
+    private val getRecentlyReleasedMoviesUseCase: GetRecentlyReleasedMoviesUseCase,
     private val getRecentlyReleasedSeriesUseCase: GetRecentlyReleasedSeriesUseCase,
     private val getTopRatedSeriesUseCase: GetTopRatedSeriesUseCase,
     private val getUpcomingMoviesUseCase: GetUpcomingMoviesUseCase,
@@ -44,7 +47,9 @@ class HomeViewModel(
 
     init {
         loadHomeScreen()
+        getRecentMovies()
     }
+
 
     private fun loadHomeScreen() {
         updateState { it.copy(isLoading = true, isError = false) }
@@ -53,32 +58,13 @@ class HomeViewModel(
             try {
                 val popularMoviesDeferred = async { getPopularityMoviesUseCase(page = 1) }
                 val popularSeriesDeferred = async { getPopularitySeriesUseCase(page = 1) }
-                val recentMoviesDeferred = async { getRecentlyReleasedMoviesUseCase() }
+                val recentMoviesDeferred = async { getRecentlyReleasedMoviesUseCase(page = 1) }
                 val recentSeriesDeferred = async { getRecentlyReleasedSeriesUseCase(page = 1) }
-                val recentlyViewedMoviesDeferred = async { getRecentlyMoviesUseCase() }
-                val recentlyViewedSeriesDeferred = async { getRecentlySeriesUseCase() }
-                val recentlyViewedMovies = recentlyViewedMoviesDeferred.await()
-                val recentlyViewedSeries = recentlyViewedSeriesDeferred.await()
+
                 val popularMovies = popularMoviesDeferred.await()
                 val popularSeries = popularSeriesDeferred.await()
                 val recentMovies = recentMoviesDeferred.await()
                 val recentSeries = recentSeriesDeferred.await()
-
-
-                val recommendedSeries = recentlyViewedSeries.firstOrNull()
-                    ?.let { getRecommendedSeriesUseCase(it.id.toLong(), 1) } ?: emptyList()
-                val recommendedMovies = recentlyViewedMovies.firstOrNull()
-                    ?.let { getRecommendedMovieUseCase(it.id, 1) } ?: emptyList()
-
-                val recommendedSeriesUi = recommendedSeries.map { it.toHomeUiModel() }
-                val recommendedMoviesUi = recommendedMovies.map { it.toHomeUiModel() }
-                val recentlyViewedMovieUi = recentlyViewedMovies.map { it.toHomeUiModel() }
-                val recentlyViewedSeriesUi = recentlyViewedSeries.map { it.toHomeUiModel() }
-
-                val recentlyViewed = recentlyViewedSeriesUi + recentlyViewedMovieUi
-                val pickedForYou = recommendedSeriesUi + recommendedMoviesUi
-
-
                 val topRated = getTopRatedSeriesUseCase(page = 1)
                 val upcoming = getUpcomingMoviesUseCase(page = 1)
 
@@ -86,12 +72,10 @@ class HomeViewModel(
                     val genres = getMoviesGenresByIdsUseCase(movie.genresID).map { it.title }
                     movie.toPopularMediaUiModel(genres)
                 }
-
                 val popularSeriesUi = popularSeries.map { series ->
                     val genres = getSeriesGenresByIdsUseCase(series.genreIDs).map { it.title }
                     series.toPopularMediaUiModel(genres)
                 }
-
                 val recentMovieUi = recentMovies.map { it.toHomeUiModel() }
                 val recentSeriesUi = recentSeries.map { it.toHomeUiModel() }
                 val topRatedUi = topRated.map { it.toHomeUiModel() }
@@ -101,11 +85,9 @@ class HomeViewModel(
                     it.copy(
                         isLoading = false,
                         isError = false,
-                        matchVibes = pickedForYou,
                         popularity = popularMovieUi + popularSeriesUi,
                         recentlyReleased = recentMovieUi + recentSeriesUi,
                         topRated = topRatedUi,
-                        recentlyViewed = recentlyViewed,
                         upcomingMovies = upcomingUi
                     )
                 }
@@ -114,6 +96,19 @@ class HomeViewModel(
                 val errorResId = mapExceptionToStringRes(e)
                 updateState { it.copy(isLoading = false, isError = true) }
                 sendEffect(HomeEffect.ShowError(errorResId))
+            }
+        }
+    }
+
+    private fun getRecentMovies() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getRecentlyMoviesUseCase().collectLatest { movies ->
+                updateState { it.copy(recentlyViewed = movies.map(Movie::toHomeUiModel)) }
+                movies.firstOrNull()?.let { movie ->
+                    val recommendedMovies =
+                        getRecommendedMovieUseCase(movie.id, 1).map(Movie::toHomeUiModel)
+                    updateState { it.copy(matchVibes = recommendedMovies) }
+                }
             }
         }
     }

--- a/presentation/home/src/main/java/com/giraffe/home/screen/movies_list/MoviesListViewModel.kt
+++ b/presentation/home/src/main/java/com/giraffe/home/screen/movies_list/MoviesListViewModel.kt
@@ -13,6 +13,7 @@ import com.giraffe.media.exception.MediaException
 import com.giraffe.media.exception.NotFoundException
 import com.giraffe.media.exception.UnknownException
 import com.giraffe.media.exception.ValidationException
+import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.usecase.GetRecentlyMoviesUseCase
 import com.giraffe.media.movies.usecase.GetRecentlyReleasedMoviesUseCase
 import com.giraffe.media.movies.usecase.GetRecommendedMovieUseCase
@@ -22,7 +23,9 @@ import com.giraffe.media.series.usecase.GetRecentlyReleasedSeriesUseCase
 import com.giraffe.media.series.usecase.GetRecommendedSeriesUseCase
 import com.giraffe.media.series.usecase.GetTopRatedSeriesUseCase
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlin.collections.emptyList
 
 class MoviesListViewModel(
     private val getRecentlyReleasedMoviesUseCase: GetRecentlyReleasedMoviesUseCase,
@@ -55,14 +58,12 @@ class MoviesListViewModel(
 
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val media = when (sectionType) {
+                when (sectionType) {
                     MovieSectionType.RECENTLY_RELEASED -> {
                         val recentMovies = getRecentlyReleasedMoviesUseCase(page = 1)
                         val recentSeries = getRecentlyReleasedSeriesUseCase(page = 1)
-
                         val moviesUi = recentMovies.map { it.toPosterUi() }
                         val seriesUi = recentSeries.map { it.toPosterUi() }
-
                         moviesUi + seriesUi
                     }
 
@@ -76,40 +77,9 @@ class MoviesListViewModel(
                         upcoming.map { it.toPosterUi() }
                     }
 
-                    MovieSectionType.RECENTLY_VIEWED -> {
-                        val recentlyViewedMovies = getRecentlyMoviesUseCase()
-                        val recentlyViewedSeries = getRecentlySeriesUseCase()
+                    MovieSectionType.RECENTLY_VIEWED -> getRecent()
 
-                        val moviesUi = recentlyViewedMovies.map { it.toPosterUi() }
-                        val seriesUi = recentlyViewedSeries.map { it.toPosterUi() }
-
-                        moviesUi + seriesUi
-                    }
-
-                    MovieSectionType.MATCHES_YOUR_VIBES -> {
-                        val recentlyViewedMovies = getRecentlyMoviesUseCase()
-                        val recentlyViewedSeries = getRecentlySeriesUseCase()
-
-                        val recommendedMovies = recentlyViewedMovies.firstOrNull()
-                            ?.let { getRecommendedMovieUseCase(it.id, 1) } ?: emptyList()
-                        val recommendedSeries = recentlyViewedSeries.firstOrNull()
-                            ?.let { getRecommendedSeriesUseCase(it.id.toLong(), 1) } ?: emptyList()
-
-                        val moviesUi = recommendedMovies.map { it.toPosterUi() }
-                        val seriesUi = recommendedSeries.map { it.toPosterUi() }
-
-                        moviesUi + seriesUi
-                    }
-
-                    else -> emptyList()
-                }
-
-                updateState {
-                    it.copy(
-                        isLoading = false,
-                        errorMessage = null,
-                        mediaList = media,
-                    )
+                    MovieSectionType.MATCHES_YOUR_VIBES -> getRecommended()
                 }
 
             } catch (e: MediaException) {
@@ -123,6 +93,34 @@ class MoviesListViewModel(
         }
     }
 
+    private fun getRecent() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val recentMovies = getRecentlyMoviesUseCase().first()
+            updateState {
+                it.copy(
+                    isLoading = false,
+                    errorMessage = null,
+                    mediaList = recentMovies.map(Movie::toPosterUi),
+                )
+            }
+        }
+    }
+
+    private fun getRecommended() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getRecentlyMoviesUseCase().first().firstOrNull()?.id?.let { movieId ->
+                val recommendedMovies =
+                    getRecommendedMovieUseCase(movieId = movieId, page = 1).map(Movie::toPosterUi)
+                updateState {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = null,
+                        mediaList = recommendedMovies,
+                    )
+                }
+            }
+        }
+    }
 
     @StringRes
     private fun mapExceptionToStringRes(throwable: Throwable): Int {

--- a/repository/media/src/main/java/com/giraffe/media/movie/MoviesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/MoviesRepositoryImpl.kt
@@ -18,8 +18,11 @@ import com.giraffe.media.movie.mapper.toEntity
 import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.repository.MoviesRepository
 import com.giraffe.media.utils.SafeCall
+import com.giraffe.media.utils.SafeCall.mapToDomainException
 import com.giraffe.user.SessionManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class MoviesRepositoryImpl(
@@ -93,8 +96,9 @@ class MoviesRepositoryImpl(
         local.clearMovieCache()
     }
 
-    override suspend fun getRecentlyMovies() =
-        SafeCall { local.getRecentlyMovies().map(MovieCacheDto::toEntity) }
+    override fun getRecentlyMovies() = local.getRecentlyMovies().map { movies ->
+        movies.map(MovieCacheDto::toEntity)
+    }.catch { throw mapToDomainException(it) }
 
     override suspend fun clearRecentlyMovies() = SafeCall { local.clearRecentlyMovies() }
 

--- a/repository/media/src/main/java/com/giraffe/media/movie/datasource/local/MoviesLocalDataSource.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/datasource/local/MoviesLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.giraffe.media.movie.datasource.local
 
 import  com.giraffe.media.movie.datasource.local.cacheDto.MovieCacheDto
 import  com.giraffe.media.movie.datasource.local.cacheDto.MovieGenreCacheDto
+import kotlinx.coroutines.flow.Flow
 
 interface MoviesLocalDataSource {
     suspend fun getMovieById(
@@ -30,7 +31,7 @@ interface MoviesLocalDataSource {
 
     suspend fun clearRecentlyMovies()
 
-    suspend fun getRecentlyMovies(): List<MovieCacheDto>
+    fun getRecentlyMovies(): Flow<List<MovieCacheDto>>
 
     suspend fun clearMovieGenreCache()
 


### PR DESCRIPTION
This commit refactors the handling of recently viewed movies to utilize Kotlin Flows.

Key changes:
- `MovieDao.getRecentlyMovies()` now returns a `Flow<List<MovieCacheDto>>`.
- `MoviesLocalDataSource.getRecentlyMovies()` and `MovieLocalDataSourceImp.getRecentlyMovies()` now return `Flow<List<MovieCacheDto>>`.
- `MoviesRepository.getRecentlyMovies()` and `MoviesRepositoryImpl.getRecentlyMovies()` now return `Flow<List<Movie>>`.
- `GetRecentlyMoviesUseCase` now returns `Flow<List<Movie>>`.
- `HomeViewModel` and `MoviesListViewModel` now collect the flow from `GetRecentlyMoviesUseCase` to update the UI for recently viewed and recommended movies.
- `SearchViewModel` now collects the flow for recent posters.
- The `GetRecentlyReleasedMoviesUseCase` in `HomeViewModel` was updated to reflect the new expected behavior.
- Removed asynchronous calls for recently viewed and recommended movies in favor of flow collection.