### PR TITLE
Update `contentScale` in `GalleryItem`

### DIFF
--- a/presentation/details/src/main/java/com/giraffe/details/components/gallery/GalleryItem.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/components/gallery/GalleryItem.kt
@@ -27,7 +27,7 @@ fun GalleryItem(
     SafeIslamicImage(
         imageUrl = imageUrl.orEmpty(),
         contentDescription = imageUrl.orEmpty(),
-        contentScale = ContentScale.Crop,
+        contentScale = ContentScale.FillBounds,
         modifier = modifier
             .clip(RoundedCornerShape(Theme.radius.lg))
     ) {


### PR DESCRIPTION
- Changed `contentScale` from `ContentScale.Crop` to `ContentScale.FillBounds` in the `SafeIslamicImage` composable within `GalleryItem`.

https://github.com/user-attachments/assets/ecfacc89-b6f7-4273-bebf-d5b66e4f042d

