### PR TITLE
Refactor: Streamline search results and improve error handling

### DIFF
--- a/datasource/local/media/src/main/java/com/giraffe/media/series/dao/SeriesDao.kt
+++ b/datasource/local/media/src/main/java/com/giraffe/media/series/dao/SeriesDao.kt
@@ -55,7 +55,7 @@ interface SeriesDao {
     suspend fun insertGenres(genres: List<SeriesGenreCacheDto>)
 
     @Query("SELECT * FROM $SERIES_GENRE_TABLE  ORDER BY count DESC")
-    fun getAllGenres(): List<SeriesGenreCacheDto>
+    suspend fun getAllGenres(): List<SeriesGenreCacheDto>
 
     @Query("DELETE FROM $SERIES_GENRE_TABLE")
     suspend fun clearAllGenres()

--- a/domain/media/src/main/java/com/giraffe/media/movies/usecase/SearchMovieByNameUseCase.kt
+++ b/domain/media/src/main/java/com/giraffe/media/movies/usecase/SearchMovieByNameUseCase.kt
@@ -8,18 +8,10 @@ class SearchMovieByNameUseCase @Inject constructor(
     private val repository: MoviesRepository
 ) {
     suspend operator fun invoke(movieName: String, page: Int): List<Movie> {
-        val searchResults = repository.searchMovieByName(movieName, page)
-
-        val sortedPreferences = repository.getMoviesGenres()
-
-        if (sortedPreferences.isEmpty() || sortedPreferences.first().rank == 0) {
-            return searchResults
-        }
-
-        val favoriteGenreId = sortedPreferences.first().id
-
-        return searchResults.sortedByDescending { movie ->
-            movie.genresID.contains(favoriteGenreId)
-        }
+        val results = repository.searchMovieByName(movieName, page)
+        val topGenre = repository.getMoviesGenres().firstOrNull { it.rank != 0 }
+        return topGenre?.let { genre ->
+            results.sortedByDescending { it.genresID.contains(genre.id) }
+        } ?: results
     }
 }

--- a/domain/media/src/main/java/com/giraffe/media/series/usecase/SearchSeriesByNameUseCase.kt
+++ b/domain/media/src/main/java/com/giraffe/media/series/usecase/SearchSeriesByNameUseCase.kt
@@ -2,28 +2,16 @@ package com.giraffe.media.series.usecase
 
 import com.giraffe.media.series.entity.Series
 import com.giraffe.media.series.repository.SeriesRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class SearchSeriesByNameUseCase @Inject constructor(
     private val seriesRepository: SeriesRepository
 ) {
     suspend operator fun invoke(seriesName: String, page: Int): List<Series> {
-        return withContext(Dispatchers.IO) {
-            val searchResults = seriesRepository.searchSeriesByName(seriesName, page)
-
-            val sortedPreferences = seriesRepository.getSeriesGenres()
-
-            if (sortedPreferences.isEmpty() || sortedPreferences.first().rank == 0) {
-                searchResults
-            }
-
-            val favoriteGenreId = sortedPreferences.first().id
-
-            searchResults.sortedByDescending { series ->
-                series.genreIDs.contains(favoriteGenreId)
-            }
-        }
+        val results = seriesRepository.searchSeriesByName(seriesName, page)
+        val topGenre = seriesRepository.getSeriesGenres().firstOrNull { it.rank != 0 }
+        return topGenre?.let { genre ->
+            results.sortedByDescending { it.genreIDs.contains(genre.id) }
+        } ?: results
     }
 }

--- a/presentation/explore/src/main/java/com/giraffe/explore/base/BaseViewModel.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/base/BaseViewModel.kt
@@ -1,6 +1,5 @@
 package com.giraffe.explore.base
 
-import android.util.Log
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,84 +9,58 @@ import com.giraffe.media.exception.NotFoundException
 import com.giraffe.media.exception.UnknownException
 import com.giraffe.media.exception.ValidationException
 import com.giraffe.media.explore.R
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 
- abstract class BaseViewModel<S>(initialState: S) : ViewModel() {
+abstract class BaseViewModel<S>(initialState: S) : ViewModel() {
     private val _state = MutableStateFlow(initialState)
     val state = _state.asStateFlow()
 
-    private val _error = MutableStateFlow<Int?>(null)
-    val error = _state.asStateFlow()
-
-    private val _isConnect = MutableStateFlow<Boolean>(true)
-    val isConnect = _isConnect.asStateFlow()
-
-     protected fun <T> safeExecute(
-         coroutineScope: CoroutineScope = viewModelScope,
-         dispatcher: CoroutineDispatcher = Dispatchers.IO,
-         exceptionHandler: CoroutineExceptionHandler = handler(),
-         block:
-         suspend CoroutineScope.() -> T
-     ): Job {
-         return coroutineScope.launch(dispatcher + exceptionHandler) {
-             _isConnect.update { true }
-             block()
-         }
-     }
-
-
-     protected fun <T> safeExecute(
-         coroutineScope: CoroutineScope = viewModelScope,
-         dispatcher: CoroutineDispatcher = Dispatchers.IO,
-         onSuccess: suspend (T) -> Unit,
-         onError: (Int, Boolean) -> Unit,
-         block: suspend () -> T
-     ): Job {
-         return coroutineScope.launch(dispatcher) {
-             try {
-                 val result = block()
-                 onSuccess(result)
-             } catch (e: Throwable) {
-                 Log.e("Exception","exception caught is ${e}")
-                 onError(mapExceptionToStringRes(e), e !is NoInternetException)
-             }
-         }
-     }
-
-
-    protected fun updateState(updater: (S) -> S) {
-
-        _state.update(updater)
+    protected fun <T> safeExecute(
+        coroutineScope: CoroutineScope = viewModelScope,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        exceptionHandler: CoroutineExceptionHandler = handler(),
+        block:
+        suspend CoroutineScope.() -> T
+    ) = coroutineScope.launch(dispatcher + exceptionHandler) {
+        block()
     }
 
-     private fun handler(onError: (Int, Boolean) -> Unit = {_,_->}): CoroutineExceptionHandler {
-         return CoroutineExceptionHandler { _, throwable ->
 
-             onError(mapExceptionToStringRes(throwable), throwable !is NoInternetException)
+    protected fun <T> safeExecute(
+        coroutineScope: CoroutineScope = viewModelScope,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        onSuccess: suspend (T) -> Unit,
+        onError: (Int, Boolean) -> Unit,
+        block: suspend () -> T
+    ) = coroutineScope.launch(dispatcher + handler(onError)) {
+        onSuccess(block())
+    }
 
-         }
-     }
+    private fun handler(onError: (errorMsgRes: Int, isNetworkError: Boolean) -> Unit = { _, _ -> }) =
+        CoroutineExceptionHandler { _, throwable ->
+            onError(
+                mapExceptionToStringRes(throwable),
+                throwable is NoInternetException
+            )
+        }
+
+    protected fun updateState(updater: (S) -> S) = _state.update(updater)
 
     @StringRes
-    fun mapExceptionToStringRes(throwable: Throwable): Int {
-        return when (throwable) {
-            is NoInternetException -> R.string.error_network
-            is AccessDeniedException -> R.string.error_access_denied
-            is ValidationException -> R.string.error_validation
-            is NotFoundException -> R.string.error_not_found
-            is UnknownException -> R.string.error_unknown
-            else -> R.string.error_unknown
-        }
+    fun mapExceptionToStringRes(throwable: Throwable) = when (throwable) {
+        is NoInternetException -> R.string.error_network
+        is AccessDeniedException -> R.string.error_access_denied
+        is ValidationException -> R.string.error_validation
+        is NotFoundException -> R.string.error_not_found
+        is UnknownException -> R.string.error_unknown
+        else -> R.string.error_unknown
     }
-
 }

--- a/presentation/explore/src/main/java/com/giraffe/explore/components/TransitionLazyColumnToGrid.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/components/TransitionLazyColumnToGrid.kt
@@ -29,6 +29,7 @@ import com.giraffe.designsystem.uimodel.Poster
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun TransitionLazyColumnToGrid(
+    modifier: Modifier = Modifier,
     posters: LazyPagingItems<Poster>,
     isListSelected: Boolean = false,
     contentPadding: PaddingValues = PaddingValues(vertical = 16.dp),
@@ -84,6 +85,7 @@ fun TransitionLazyColumnToGrid(
         ) {
             if (it) {
                 LazyColumn(
+                    modifier = modifier,
                     state = listState,
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                     contentPadding = contentPadding
@@ -104,6 +106,7 @@ fun TransitionLazyColumnToGrid(
                 }
             } else {
                 LazyVerticalGrid(
+                    modifier = modifier,
                     state = gridState,
                     columns = GridCells.Fixed(2),
                     verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultInteractionListener.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultInteractionListener.kt
@@ -3,4 +3,5 @@ package com.giraffe.explore.screen.searchresult
 interface SearchResultInteractionListener {
     fun selectTap(tabIndex: Int)
     fun changeView(isGrid: Boolean)
+    fun retry()
 }

--- a/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultScreen.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultScreen.kt
@@ -1,18 +1,16 @@
 package com.giraffe.explore.screen.searchresult
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +26,7 @@ import com.giraffe.designsystem.composable.NoInternetScreen
 import com.giraffe.designsystem.composable.Progress
 import com.giraffe.designsystem.composable.Tabs
 import com.giraffe.designsystem.theme.Theme
+import com.giraffe.designsystem.uimodel.Poster
 import com.giraffe.explore.components.CastItem
 import com.giraffe.explore.components.ExploreHeader
 import com.giraffe.explore.components.NothingFound
@@ -44,29 +43,19 @@ fun SearchResultScreen(
     viewModel: SearchResultViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-
-    val isConnect = viewModel.isConnect.collectAsState()
-
-
-    LaunchedEffect (isConnect.value){ Log.e("IsInternet","${isConnect.value}") }
-
-
-        SearchResultContent(
-            state = state,
-            interactions = viewModel,
-            navigateToMovieDetails = navigateToMovieDetails,
-            navigateToSeriesDetails = navigateToSeriesDetails,
-            navigateToCastDetails = navigateToCastDetails,
-            onBackClick = onBackClick,
-            isConnect = isConnect.value
-        )
-    }
-
+    SearchResultContent(
+        state = state,
+        interactions = viewModel,
+        navigateToMovieDetails = navigateToMovieDetails,
+        navigateToSeriesDetails = navigateToSeriesDetails,
+        navigateToCastDetails = navigateToCastDetails,
+        onBackClick = onBackClick,
+    )
+}
 
 @Composable
-fun SearchResultContent(
+private fun SearchResultContent(
     state: SearchResultScreenState,
-    isConnect:Boolean,
     interactions: SearchResultInteractionListener,
     navigateToMovieDetails: (Int) -> Unit,
     navigateToSeriesDetails: (Int) -> Unit,
@@ -74,7 +63,6 @@ fun SearchResultContent(
     onBackClick: () -> Unit,
 ) {
     val context = LocalContext.current
-    val actors = state.actors.collectAsLazyPagingItems()
     val posters = state.selectedPosters.collectAsLazyPagingItems()
     Box {
         LazyColumn(
@@ -103,56 +91,37 @@ fun SearchResultContent(
                     onTabSelected = interactions::selectTap
                 )
             }
-
             item {
                 Box(
                     modifier = Modifier.fillParentMaxSize(),
+                    contentAlignment = Alignment.Center
                 ) {
-                    if (state.isNetworkError == isConnect) {
-                        NoInternetScreen()
-                    } else {
+                    when {
+                        posters.loadState.refresh is LoadState.Loading -> Progress(size = 32.dp)
+                        posters.loadState.hasError && posters.itemCount == 0 -> NoInternetScreen(
+                            onRetryClick = interactions::retry
+                        )
 
-                        if (posters.loadState.refresh is LoadState.Loading) {
-                            Progress(
-                                size = 32.dp,
-                                modifier = Modifier
-                                    .align(Alignment.TopCenter)
-                                    .padding(top = 16.dp)
+                        posters.itemCount == 0 -> NothingFound()
+                        else -> if (state.selectedTab == SearchTab.ACTORS) {
+                            ActorsSection(
+                                modifier = Modifier.fillMaxSize(),
+                                actors = posters,
+                                navigateToCastDetails = navigateToCastDetails
                             )
                         } else {
-                            // Show content based on selected tab
-                            if (state.selectedTab == SearchTab.ACTORS) {
-                                if (actors.itemCount != 0) {
-                                    ActorsSection(
-                                        actors = actors,
-                                        navigateToCastDetails = navigateToCastDetails
-                                    )
-                                } else {
-                                    NothingFound(
-                                        modifier = Modifier
-                                            .padding(horizontal = 60.dp)
-                                            .padding(top = 195.dp)
-                                    )
-                                }
-                            } else if (posters.itemCount != 0) {
-                                TransitionLazyColumnToGrid(
-                                    posters = posters,
-                                    isListSelected = !state.isGridSelected,
-                                    onPosterClicked = { id ->
-                                        when (state.selectedTab) {
-                                            SearchTab.MOVIES -> navigateToMovieDetails(id)
-                                            SearchTab.SERIES -> navigateToSeriesDetails(id)
-                                            SearchTab.ACTORS -> navigateToCastDetails(id)
-                                        }
+                            TransitionLazyColumnToGrid(
+                                modifier = Modifier.fillMaxSize(),
+                                posters = posters,
+                                isListSelected = !state.isGridSelected,
+                                onPosterClicked = { id ->
+                                    when (state.selectedTab) {
+                                        SearchTab.MOVIES -> navigateToMovieDetails(id)
+                                        SearchTab.SERIES -> navigateToSeriesDetails(id)
+                                        SearchTab.ACTORS -> navigateToCastDetails(id)
                                     }
-                                )
-                            } else {
-                                NothingFound(
-                                    modifier = Modifier
-                                        .padding(horizontal = 60.dp)
-                                        .padding(top = 195.dp)
-                                )
-                            }
+                                }
+                            )
                         }
                     }
                 }
@@ -160,10 +129,11 @@ fun SearchResultContent(
         }
     }
 }
+
 @Composable
-fun ActorsSection(
+private fun ActorsSection(
     modifier: Modifier = Modifier,
-    actors: LazyPagingItems<ActorUi>,
+    actors: LazyPagingItems<Poster>,
     navigateToCastDetails: (Int) -> Unit
 ) {
     LazyVerticalGrid(
@@ -176,13 +146,12 @@ fun ActorsSection(
         items(actors.itemCount) { actorIndex ->
             CastItem(
                 name = actors[actorIndex]?.name.toString(),
-                imageUrl = actors[actorIndex]?.imageUrl.toString(),
+                imageUrl = actors[actorIndex]?.imageUri.toString(),
                 onClick = {
                     navigateToCastDetails(actors[actorIndex]?.id ?: 0)
                 }
             )
         }
     }
-
 }
 

--- a/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultScreenState.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultScreenState.kt
@@ -19,18 +19,10 @@ data class SearchResultScreenState(
     @Transient
     val seriesPosters: Flow<PagingData<Poster>> = flowOf(),
     @Transient
-    val actors: Flow<PagingData<ActorUi>> = flowOf(),
+    val actorsPosters: Flow<PagingData<Poster>> = flowOf(),
     val moviesGenres: List<GenreUi> = emptyList(),
     val seriesGenres: List<GenreUi> = emptyList(),
     val errorMessage: Int? = null,
     val isNetworkError: Boolean = false,
-    val isLoading:Boolean=false,
-
-
-)
-
-data class ActorUi(
-    val id: Int,
-    val name: String,
-    val imageUrl: String
+    val isLoading: Boolean = false,
 )

--- a/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultViewModel.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/screen/searchresult/SearchResultViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.giraffe.explore.base.BaseViewModel
@@ -20,6 +21,7 @@ import com.giraffe.media.series.entity.Series
 import com.giraffe.media.series.usecase.GetSeriesGenresUseCase
 import com.giraffe.media.series.usecase.SearchSeriesByNameUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -33,12 +35,9 @@ class SearchResultViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<SearchResultScreenState>(
     SearchResultScreenState(query = savedStateHandle.get<String>("query").orEmpty()),
-),
-    SearchResultInteractionListener {
-
+), SearchResultInteractionListener {
 
     init {
-
         getMoviesGenres()
         getSeriesGenres()
         getMovies()
@@ -47,18 +46,24 @@ class SearchResultViewModel @Inject constructor(
     }
 
     override fun selectTap(tabIndex: Int) {
-        safeExecute {
-            updateState { it.copy(selectedTab = SearchTab.entries[tabIndex]) }
-            when (state.value.selectedTab) {
-                SearchTab.MOVIES -> updateState { it.copy(selectedPosters = state.value.moviesPosters) }
-                SearchTab.SERIES -> updateState { it.copy(selectedPosters = state.value.seriesPosters) }
-                SearchTab.ACTORS -> {}
-            }
+        updateState { it.copy(selectedTab = SearchTab.entries[tabIndex]) }
+        when (state.value.selectedTab) {
+            SearchTab.MOVIES -> updateState { it.copy(selectedPosters = state.value.moviesPosters) }
+            SearchTab.SERIES -> updateState { it.copy(selectedPosters = state.value.seriesPosters) }
+            SearchTab.ACTORS -> updateState { it.copy(selectedPosters = state.value.actorsPosters) }
         }
     }
 
     override fun changeView(isGrid: Boolean) {
-        safeExecute { updateState { it.copy(isGridSelected = isGrid) } }
+        updateState { it.copy(isGridSelected = isGrid) }
+    }
+
+    override fun retry() {
+        getMoviesGenres()
+        getSeriesGenres()
+        getMovies()
+        getSeries()
+        getActors()
     }
 
 
@@ -67,10 +72,9 @@ class SearchResultViewModel @Inject constructor(
             onSuccess = { genres ->
                 updateState { it.copy(moviesGenres = genres.map { genre -> genre.toUi() }) }
             },
-            onError = ::onFail
-        ) {
-            getMoviesGenresUseCase()
-        }
+            onError = ::onFail,
+            block = getMoviesGenresUseCase::invoke,
+        )
     }
 
     private fun getSeriesGenres() {
@@ -78,62 +82,95 @@ class SearchResultViewModel @Inject constructor(
             onSuccess = { genres ->
                 updateState { it.copy(seriesGenres = genres.map { genre -> genre.toUi() }) }
             },
-            onError = ::onFail
-        ) {
-            getSeriesGenresUseCase()
-        }
+            onError = ::onFail,
+            block = getSeriesGenresUseCase::invoke,
+        )
     }
 
     private fun getMovies() {
         safeExecute(
-            onSuccess = { flow ->
-                val moviesFlow = flow
-                    .map { it.map(Movie::toPoster) }
-                updateState { it.copy(selectedPosters = moviesFlow, moviesPosters = moviesFlow) }
-            },
-            onError = ::onFail
+            onSuccess = ::onGetMoviesSuccess,
+            onError = ::onFail,
         ) {
-            val moviesFlow = Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
+            Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
                 BasePagingSource { page -> searchMovieByName(state.value.query, page) }
             }.flow.cachedIn(viewModelScope)
-            moviesFlow
+        }
+    }
+
+    private fun onGetMoviesSuccess(moviesFlow: Flow<PagingData<Movie>>) {
+        moviesFlow.map { it.map(Movie::toPoster) }.let { posters ->
+            updateState {
+                it.copy(
+                    moviesPosters = posters,
+                    errorMessage = null,
+                    isNetworkError = false
+                )
+            }
+            if (state.value.selectedTab == SearchTab.MOVIES) updateState {
+                it.copy(selectedPosters = posters)
+            }
         }
     }
 
     private fun getSeries() {
         safeExecute(
-            onSuccess = { flow ->
-                val seriesFlow = flow
-                    .map { it.map(Series::toPoster) }
-                updateState { it.copy(seriesPosters = seriesFlow) }
-            },
+            onSuccess = ::onGetSeriesSuccess,
             onError = ::onFail
         ) {
-            val seriesFlow = Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
+            Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
                 BasePagingSource { page -> searchSeriesByName(state.value.query, page) }
             }.flow.cachedIn(viewModelScope)
-            seriesFlow
+        }
+    }
+
+    private fun onGetSeriesSuccess(seriesFlow: Flow<PagingData<Series>>) {
+        seriesFlow.map { series -> series.map(Series::toPoster) }.let { posters ->
+            updateState {
+                it.copy(
+                    seriesPosters = posters,
+                    errorMessage = null,
+                    isNetworkError = false
+                )
+            }
+            if (state.value.selectedTab == SearchTab.SERIES) updateState {
+                it.copy(selectedPosters = posters)
+            }
         }
     }
 
     private fun getActors() {
         safeExecute(
-            onSuccess = { flow ->
-                val actorsFlow = flow
-                    .map { it.map(Person::toUi) }
-                updateState { it.copy(actors = actorsFlow, errorMessage = null, isNetworkError = true) }
-            },
+            onSuccess = ::onGetActorsSuccess,
             onError = ::onFail
         ) {
-            val actorsFlow = Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
+            Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
                 BasePagingSource { page -> searchPeopleByName(state.value.query, page) }
             }.flow.cachedIn(viewModelScope)
-            actorsFlow
         }
     }
 
+    private fun onGetActorsSuccess(actorsFlow: Flow<PagingData<Person>>) {
+        actorsFlow.map { actors -> actors.map(Person::toPoster) }.let { posters ->
+            updateState {
+                it.copy(
+                    actorsPosters = posters,
+                    errorMessage = null,
+                    isNetworkError = false
+                )
+            }
+            if (state.value.selectedTab == SearchTab.ACTORS) updateState {
+                it.copy(selectedPosters = posters)
+            }
+        }
+    }
 
-    private fun onFail(errorMsgRes: Int, isConnected: Boolean) =
-        updateState { it.copy(errorMessage = errorMsgRes, isNetworkError = isConnected) }
-
+    private fun onFail(errorMsgRes: Int, isNetworkError: Boolean) {
+        updateState {
+            it.copy(
+                errorMessage = errorMsgRes,
+                isNetworkError = isNetworkError
+            )
+        }
+    }
 }

--- a/presentation/explore/src/main/java/com/giraffe/explore/util/Mapper.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/util/Mapper.kt
@@ -2,7 +2,6 @@ package com.giraffe.explore.util
 
 import com.giraffe.designsystem.uimodel.Poster
 import com.giraffe.explore.screen.discover.GenreUi
-import com.giraffe.explore.screen.searchresult.ActorUi
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.person.entity.Person
@@ -51,5 +50,4 @@ fun Person.toPoster() = Poster(
     mediaTypeOfPoster = Poster.Type.PERSON.value
 )
 
-fun Person.toUi() = ActorUi(id, name, imageUrl.toString())
 fun Genre.toUi() = GenreUi(id, title)

--- a/repository/media/src/main/java/com/giraffe/media/movie/MoviesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/MoviesRepositoryImpl.kt
@@ -2,8 +2,6 @@ package com.giraffe.media.movie
 
 import com.giraffe.media.dto.ReviewDto
 import com.giraffe.media.entity.Genre
-import com.giraffe.media.explore.datasource.local.LocalExploreDataSource
-import com.giraffe.media.explore.datasource.local.cacheDto.SearchKeywordCacheDto
 import com.giraffe.media.mapper.toEntity
 import com.giraffe.media.movie.datasource.local.MoviesLocalDataSource
 import com.giraffe.media.movie.datasource.local.cacheDto.MovieCacheDto
@@ -29,29 +27,10 @@ import javax.inject.Inject
 class MoviesRepositoryImpl @Inject constructor(
     private val local: MoviesLocalDataSource,
     private val remote: MoviesRemoteDataSource,
-    private val localExploreDataSource: LocalExploreDataSource
 ) : MoviesRepository {
 
     override suspend fun searchMovieByName(movieName: String, page: Int) = SafeCall {
-        withContext(Dispatchers.IO) {
-            val keywordData = localExploreDataSource.getSearchKeyword(query = movieName)
-            val isPageCached = keywordData?.moviesPages?.contains(page) == true
-            if (isPageCached) {
-                local.getMoviesByName(movieName, page).map(MovieCacheDto::toEntity)
-            } else {
-                val remoteMovies = remote.getMoviesByName(movieName, page).map(MovieDto::toEntity)
-                val updatedKeyword = keywordData?.copy(
-                    moviesPages = keywordData.moviesPages + page,
-                    searchedAt = System.currentTimeMillis()
-                ) ?: SearchKeywordCacheDto(
-                    keyword = movieName,
-                    moviesPages = listOf(page)
-                )
-                localExploreDataSource.insertSearchKeyword(updatedKeyword)
-                local.insertMovies(remoteMovies.map { it.toCacheDto().copy(page = page) })
-                remoteMovies
-            }
-        }
+        remote.getMoviesByName(movieName, page).map(MovieDto::toEntity)
     }
 
 

--- a/repository/media/src/main/java/com/giraffe/media/person/PersonRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/person/PersonRepositoryImpl.kt
@@ -1,7 +1,5 @@
 package com.giraffe.media.person
 
-import com.giraffe.media.explore.datasource.local.LocalExploreDataSource
-import com.giraffe.media.explore.datasource.local.cacheDto.SearchKeywordCacheDto
 import com.giraffe.media.person.datasource.local.PersonLocalDataSource
 import com.giraffe.media.person.datasource.local.cacheDto.PersonCacheDto
 import com.giraffe.media.person.datasource.remote.PersonRemoteDataSource
@@ -25,31 +23,10 @@ import javax.inject.Inject
 class PersonRepositoryImpl @Inject constructor(
     private val remoteDataSource: PersonRemoteDataSource,
     private val localDataSource: PersonLocalDataSource,
-    private val localExploreDataSource: LocalExploreDataSource,
 ) : PersonRepository {
 
     override suspend fun searchByName(personName: String, page: Int) = SafeCall {
-        withContext(Dispatchers.IO) {
-            val keywordData = localExploreDataSource.getSearchKeyword(query = personName)
-            val isPageCached = keywordData?.actorsPages?.contains(page) == true
-            if (isPageCached) {
-                localDataSource.searchByName(personName, page).map(PersonCacheDto::toEntity)
-            } else {
-                val remoteActors =
-                    remoteDataSource.searchByName(personName, page).map(PersonDto::toEntity)
-                val updatedKeyword = keywordData?.copy(
-                    actorsPages = keywordData.actorsPages + page,
-                    searchedAt = System.currentTimeMillis()
-                ) ?: SearchKeywordCacheDto(
-                    keyword = personName,
-                    actorsPages = listOf(page)
-                )
-                localExploreDataSource.insertSearchKeyword(updatedKeyword)
-                localDataSource.insertPeople(remoteActors.map { it.toCacheDto().copy(page = page) })
-                remoteActors
-            }
-        }
-
+        remoteDataSource.searchByName(personName, page).map(PersonDto::toEntity)
     }
 
     override suspend fun addRecentPerson(person: Person) =

--- a/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
@@ -2,11 +2,8 @@ package com.giraffe.media.series
 
 import com.giraffe.media.dto.ReviewDto
 import com.giraffe.media.entity.Genre
-import com.giraffe.media.explore.datasource.local.LocalExploreDataSource
-import com.giraffe.media.explore.datasource.local.cacheDto.SearchKeywordCacheDto
 import com.giraffe.media.mapper.toEntity
 import com.giraffe.media.series.datasource.local.SeriesLocalDateSource
-import com.giraffe.media.series.datasource.local.cacheDto.SeriesCacheDto
 import com.giraffe.media.series.datasource.local.cacheDto.SeriesGenreCacheDto
 import com.giraffe.media.series.datasource.remote.SeriesRemoteDataSource
 import com.giraffe.media.series.datasource.remote.dto.GenreDto
@@ -20,33 +17,16 @@ import com.giraffe.media.series.repository.SeriesRepository
 import com.giraffe.media.utils.SafeCall
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import kotlinx.coroutines.flow.map
 
 class SeriesRepositoryImpl @Inject constructor(
     private val remote: SeriesRemoteDataSource,
     private val local: SeriesLocalDateSource,
-    private val localExploreDataSource: LocalExploreDataSource
 ) : SeriesRepository {
     override suspend fun searchSeriesByName(seriesName: String, page: Int) = SafeCall {
-        val keywordData = localExploreDataSource.getSearchKeyword(query = seriesName)
-        val isPageCached = keywordData?.seriesPages?.contains(page) == true
-        if (isPageCached) {
-            local.getCachedSeriesForName(seriesName, page).map(SeriesCacheDto::toEntity)
-        } else {
-            val remoteSeries = remote.getSeriesByName(seriesName, page).map(SeriesDto::toEntity)
-            val updatedKeyword = keywordData?.copy(
-                seriesPages = keywordData.seriesPages + page,
-                searchedAt = System.currentTimeMillis()
-            ) ?: SearchKeywordCacheDto(
-                keyword = seriesName,
-                seriesPages = listOf(page)
-            )
-            localExploreDataSource.insertSearchKeyword(updatedKeyword)
-            local.insertSearchResult(remoteSeries.map { it.toCacheDto().copy(page = page) })
-            remoteSeries
-        }
+        remote.getSeriesByName(seriesName, page).map(SeriesDto::toEntity)
     }
 
     override suspend fun getSeriesGenres(): List<Genre> = SafeCall {


### PR DESCRIPTION

This PR refactors the search functionality to remove local caching for series, movies, and actors, directly fetching data from the remote source.

Key changes:
- Removed local caching for search results in `SeriesRepositoryImpl`, `MoviesRepositoryImpl`, and `PersonRepositoryImpl`.
- Simplified search use cases (`SearchMovieByNameUseCase`, `SearchSeriesByNameUseCase`) by removing genre-based sorting if no preferred genres are set.
- Updated `SearchResultViewModel` to:
    - Handle actors as `Poster` objects instead of `ActorUi`.
    - Improve error handling and state updates for movies, series, and actors.
    - Added a `retry` function to reload data.
- Refactored `SearchResultScreen` to:
    - Simplify content display logic and error handling.
    - Adapt `ActorsSection` to use `Poster` objects.
- Modified `BaseViewModel` for more concise error handling.
- Ensured `getAllGenres` in `SeriesDao` is a suspend function.
- Minor UI adjustments in `TransitionLazyColumnToGrid`.

https://github.com/user-attachments/assets/feb75f83-50b3-4e1e-958b-ae5f0538ea32