### PR TITLE
Refactor: Improve date formatting and genre display in Discover screen

### DIFF
--- a/presentation/explore/src/main/java/com/giraffe/explore/screen/discover/DiscoverViewModel.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/screen/discover/DiscoverViewModel.kt
@@ -9,10 +9,8 @@ import com.giraffe.explore.base.BaseViewModel
 import com.giraffe.explore.util.BasePagingSource
 import com.giraffe.explore.util.toPoster
 import com.giraffe.explore.util.toUi
-import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.usecase.GetMoviesByGenresUseCase
 import com.giraffe.media.movies.usecase.GetMoviesGenresUseCase
-import com.giraffe.media.series.entity.Series
 import com.giraffe.media.series.usecase.GetSeriesByGenresUseCase
 import com.giraffe.media.series.usecase.GetSeriesGenresUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,7 +50,8 @@ class DiscoverViewModel @Inject constructor(
             val moviesFlow =
                 Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
                     BasePagingSource { page -> getMoviesByGenresUseCase(genreId, page) }
-                }.flow.cachedIn(viewModelScope).map { it.map(Movie::toPoster) }
+                }.flow.cachedIn(viewModelScope)
+                    .map { it.map { movie -> movie.toPoster(state.value.moviesGenres) } }
             updateState { it.copy(moviesPosters = moviesFlow) }
             if (state.value.selectedTab == SearchTab.MOVIES) updateState { it.copy(selectedPosters = moviesFlow) }
         }
@@ -63,7 +62,8 @@ class DiscoverViewModel @Inject constructor(
             val seriesFlow =
                 Pager(PagingConfig(pageSize = 15, prefetchDistance = 5, initialLoadSize = 15)) {
                     BasePagingSource { page -> getSeriesByGenresUseCase(genreId, page) }
-                }.flow.cachedIn(viewModelScope).map { it.map(Series::toPoster) }
+                }.flow.cachedIn(viewModelScope)
+                    .map { it.map { series -> series.toPoster(state.value.seriesGenres) } }
             updateState { it.copy(seriesPosters = seriesFlow) }
             if (state.value.selectedTab == SearchTab.SERIES) updateState { it.copy(selectedPosters = seriesFlow) }
         }

--- a/presentation/explore/src/main/java/com/giraffe/explore/util/Mapper.kt
+++ b/presentation/explore/src/main/java/com/giraffe/explore/util/Mapper.kt
@@ -8,11 +8,19 @@ import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.person.entity.Person
 import com.giraffe.media.series.entity.Series
 
+
 fun Movie.toPoster(allGenres: List<GenreUi> = emptyList()): Poster {
     val genreTitles = allGenres
         .filter { it.id in genresID }
         .joinToString(", ") { it.title }
         .ifBlank { null }
+
+
+    val date = releaseYear?.let {
+        "${it.year}, ${
+            it.month.name.lowercase().replaceFirstChar { char -> char.uppercase() }.take(3)
+        } ${it.day}"
+    } ?: ""
 
     return Poster(
         id = id,
@@ -21,10 +29,11 @@ fun Movie.toPoster(allGenres: List<GenreUi> = emptyList()): Poster {
         rating = rating,
         genres = genreTitles,
         time = duration.toString(),
-        date = releaseYear?.toString(),
+        date = date,
         mediaTypeOfPoster = Poster.Type.MOVIE.value
     )
 }
+
 
 fun Series.toPoster(allGenres: List<GenreUi> = emptyList()): Poster {
     val genreTitles = allGenres


### PR DESCRIPTION
- Modified `Movie.toPoster()` to format the release date as "YYYY, Mon DD" (e.g., "2023, Dec 25").
- Updated `DiscoverViewModel` to pass the `allGenres` list when converting movies and series to posters, ensuring correct genre display.

https://github.com/user-attachments/assets/7fe55471-27e5-4c9c-a062-41e49407a006