### PR TITLE
feat: Integrate Login Screen into Profile Navigation

### DIFF
--- a/presentation/profile/src/main/java/com/giraffe/profile/navigation/LoginRoute.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/navigation/LoginRoute.kt
@@ -1,11 +1,26 @@
 package com.giraffe.profile.navigation
 
 import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.giraffe.authentication.AuthenticationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
 internal object LoginRoute
 
-internal fun NavController.navigateToLogin() {
+internal fun NavController.navigateLoginScreen() {
     navigate(LoginRoute)
+}
+
+internal fun NavGraphBuilder.loginRoute(
+    authApi: AuthenticationApi
+) {
+    composable<LoginRoute> {
+        authApi.LoginContainer(
+            onBack = {},
+            isOnboardingFirstTime = false,
+            isLoggedIn = false
+        )
+    }
 }

--- a/presentation/profile/src/main/java/com/giraffe/profile/navigation/ProfileApiImp.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/navigation/ProfileApiImp.kt
@@ -3,14 +3,17 @@ package com.giraffe.profile.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.giraffe.authentication.AuthenticationApi
 import com.giraffe.details.DetailsApi
 import com.giraffe.explore.ExploreApi
 import com.giraffe.profile.ProfileApi
 import com.giraffe.profile.screens.collections.mycollections.MyCollectionsRoute
 import com.giraffe.profile.screens.settings.SettingsScreenRoute
 import javax.inject.Inject
+import javax.inject.Provider
 
 class ProfileApiImp @Inject constructor(
+    private val authApiProvider: Provider<AuthenticationApi>,
     private val detailsApi: DetailsApi,
     private val exploreApi: ExploreApi,
 ) : ProfileApi {
@@ -23,6 +26,7 @@ class ProfileApiImp @Inject constructor(
         ProfileNavGraph(
             navController = navController,
             startDestinationRoute = MyCollectionsRoute,
+            authenticationApi = authApiProvider.get(),
             detailsApi = detailsApi,
             exploreApi = exploreApi,
             onShowBottomBarChange = onShowBottomBarChange
@@ -38,6 +42,7 @@ class ProfileApiImp @Inject constructor(
         ProfileNavGraph(
             navController = navController,
             startDestinationRoute = SettingsScreenRoute,
+            authenticationApi = authApiProvider.get(),
             detailsApi = detailsApi,
             exploreApi = exploreApi,
             onShowBottomBarChange = onShowBottomBarChange

--- a/presentation/profile/src/main/java/com/giraffe/profile/navigation/ProfileNavGraph.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/navigation/ProfileNavGraph.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.toRoute
+import com.giraffe.authentication.AuthenticationApi
 import com.giraffe.details.DetailsApi
 import com.giraffe.explore.ExploreApi
 import com.giraffe.profile.edit.editProfileWebViewRoute
@@ -30,6 +31,7 @@ internal fun ProfileNavGraph(
     modifier: Modifier = Modifier,
     navController: NavHostController,
     startDestinationRoute: Any,
+    authenticationApi: AuthenticationApi,
     detailsApi: DetailsApi,
     exploreApi: ExploreApi,
     onShowBottomBarChange: (Boolean) -> Unit
@@ -63,7 +65,7 @@ internal fun ProfileNavGraph(
     ) {
         settingsScreenRoute(
             navController = navController,
-            onNavigateToLogin = {  },
+            onNavigateToLogin = navController::navigateLoginScreen,
             onNavigateToMyCollections = navController::navigateToMyCollections,
             onNavigateToHistory = navController::navigateToHistory,
             onNavigateToRatings = navController::navigateToRatings,
@@ -117,6 +119,8 @@ internal fun ProfileNavGraph(
                 onBackClick = navController::popBackStack
             )
         }
+
+        loginRoute(authenticationApi)
     }
 
 }


### PR DESCRIPTION

This PR integrates the login screen from the authentication module into the profile feature's navigation graph.

Key changes include:
- Added `loginRoute` to `ProfileNavGraph.kt` to handle navigation to the login screen.
- Updated `ProfileNavGraph.kt` to accept an `AuthenticationApi` dependency for accessing the login screen.
- `ProfileApiImp.kt` now injects `AuthenticationApi` and passes it to `ProfileNavGraph`.
- Renamed `navigateToLogin` to `navigateLoginScreen` in `LoginRoute.kt` for clarity and added `loginRoute` composable function to display the login UI.
- Updated `settingsScreenRoute` in `ProfileNavGraph.kt` to use `navController::navigateLoginScreen` for navigating to the login screen.