### PR TITLE
Make SettingsScreen scrollable

### DIFF
--- a/presentation/profile/src/main/java/com/giraffe/profile/screens/settings/SettingsScreen.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/screens/settings/SettingsScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -49,7 +51,7 @@ fun SettingsScreen(
             when (effect) {
                 is SettingsScreenEffect.NavigateToLogin -> onNavigateToLogin()
                 is SettingsScreenEffect.NavigateToEditProfileWebsite -> onNavigateToEditProfileWebView()
-                else -> {}
+                is SettingsScreenEffect.ShowError -> {}
             }
         }
     }
@@ -76,6 +78,7 @@ fun SettingsContent(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .background(color = Theme.color.background.screen)
             .statusBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION

The SettingsScreen was made scrollable to accommodate more options and improve user experience on smaller screens.
This was achieved by adding the `verticalScroll` modifier to the main `Column` composable.
Additionally, an unused case in the `LaunchedEffect` for `SettingsScreenEffect.ShowError` was explicitly handled.