### PR TITLE
Refactor: Update rating functionality and UI

### DIFF
--- a/datasource/remote/media/src/main/java/com/giraffe/media/movie/retrofit/MoviesApiServiceRetrofit.kt
+++ b/datasource/remote/media/src/main/java/com/giraffe/media/movie/retrofit/MoviesApiServiceRetrofit.kt
@@ -79,6 +79,7 @@ interface MoviesApiServiceRetrofit {
     ): Response<Unit>
 
     @DELETE("$MOVIE_END_POINT/{$MOVIE_ID}/$RATING")
+    @Headers("$NEEDS_SESSION: true")
     suspend fun deleteMovieRating(
         @Path(MOVIE_ID) movieId: Int,
     ): Response<Unit>
@@ -110,6 +111,7 @@ interface MoviesApiServiceRetrofit {
     ): Response<MoviesListResponse<TrailerResponse>>
 
     @GET("$USER_END_POINT/{$ACCOUNT_ID_PATH}/$RATED_END_POINT")
+    @Headers("$NEEDS_SESSION: true")
     suspend fun getRatedMovies(
         @Path(ACCOUNT_ID_PATH) accountId: Int
     ): Response<MoviesListResponse<MovieDto>>

--- a/datasource/remote/media/src/main/java/com/giraffe/media/series/retrofit/SeriesApiServiceRetrofit.kt
+++ b/datasource/remote/media/src/main/java/com/giraffe/media/series/retrofit/SeriesApiServiceRetrofit.kt
@@ -1,5 +1,6 @@
 package com.giraffe.media.series.retrofit
 
+import com.giraffe.media.movie.datasource.remote.dto.RatingRequest
 import com.giraffe.media.response.AllReviewsResponse
 import com.giraffe.media.response.TrailerResponse
 import com.giraffe.media.series.datasource.remote.dto.SeriesDetailsDto
@@ -7,12 +8,17 @@ import com.giraffe.media.series.datasource.remote.dto.SeriesDto
 import com.giraffe.media.series.response.GenresResponse
 import com.giraffe.media.series.response.SeriesResponse
 import com.giraffe.media.util.NetworkConstants.ACCOUNT_ID_PATH
+import com.giraffe.media.util.NetworkConstants.NEEDS_SESSION
 import com.giraffe.media.util.NetworkConstants.RATING
+import com.giraffe.media.util.NetworkConstants.TV_END_POINT
 import com.giraffe.media.util.NetworkConstants.USER_END_POINT
 import com.giraffe.media.util.NetworkConstants.VIDEOS_END_POINT
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -73,14 +79,24 @@ interface SeriesApiServiceRetrofit {
 
 
     @GET("$USER_END_POINT/{$ACCOUNT_ID_PATH}/$RATED/$TV")
+    @Headers("$NEEDS_SESSION: true")
     suspend fun getRatedSeries(
         @Path(ACCOUNT_ID_PATH) accountId: Int
     ): Response<SeriesResponse<SeriesDto>>
 
 
     @DELETE("$TV/{$SERIES_ID}/$RATING")
+    @Headers("$NEEDS_SESSION: true")
     suspend fun deleteSeriesRating(
         @Path(SERIES_ID) seriesId: Int,
+    ): Response<Unit>
+
+
+    @POST("$TV_END_POINT/{$SERIES_ID}/$RATING")
+    @Headers("$NEEDS_SESSION: true")
+    suspend fun rateSeries(
+        @Path(SERIES_ID) seriesId: Int,
+        @Body request: RatingRequest
     ): Response<Unit>
 
     companion object {

--- a/datasource/remote/media/src/main/java/com/giraffe/media/series/retrofit/SeriesRemoteRetrofitDataSourceImp.kt
+++ b/datasource/remote/media/src/main/java/com/giraffe/media/series/retrofit/SeriesRemoteRetrofitDataSourceImp.kt
@@ -1,5 +1,6 @@
 package com.giraffe.media.series.retrofit
 
+import com.giraffe.media.movie.datasource.remote.dto.RatingRequest
 import com.giraffe.media.series.datasource.remote.SeriesRemoteDataSource
 import com.giraffe.media.series.datasource.remote.dto.SeriesDetailsDto
 import com.giraffe.media.series.datasource.remote.dto.SeriesDto
@@ -52,4 +53,8 @@ class SeriesRemoteRetrofitDataSourceImp @Inject constructor(
 
     override suspend fun deleteSeriesRating(seriesId: Int) =
         retrofitRequestBuilder.delete { deleteSeriesRating(seriesId) }
+
+    override suspend fun addRating(serisId: Int, request: RatingRequest) {
+        retrofitRequestBuilder.post { rateSeries(serisId, request) }
+    }
 }

--- a/datasource/remote/media/src/main/java/com/giraffe/media/util/NetworkConstants.kt
+++ b/datasource/remote/media/src/main/java/com/giraffe/media/util/NetworkConstants.kt
@@ -36,5 +36,11 @@ object NetworkConstants {
 
     //rated
     const val RATED_END_POINT = "rated/movies"
+
+    //series
+    const val SERIES_ID = "series_id"
+    const val TV_END_POINT = "tv"
+
+
 }
 

--- a/domain/media/src/main/java/com/giraffe/media/series/repository/SeriesRepository.kt
+++ b/domain/media/src/main/java/com/giraffe/media/series/repository/SeriesRepository.kt
@@ -32,4 +32,6 @@ interface SeriesRepository {
     suspend fun deleteSeriesRating(seriesId: Int)
     suspend fun deleteSeriesById(seriesId: Int)
     suspend fun addTopRatedSeries(series: List<Series>)
+
+    suspend fun addRating(serisId: Int, ratingValue: Float)
 }

--- a/domain/media/src/main/java/com/giraffe/media/series/usecase/AddSeriesRatingUseCase.kt
+++ b/domain/media/src/main/java/com/giraffe/media/series/usecase/AddSeriesRatingUseCase.kt
@@ -1,0 +1,12 @@
+package com.giraffe.media.series.usecase
+
+import com.giraffe.media.series.repository.SeriesRepository
+import javax.inject.Inject
+
+class AddSeriesRatingUseCase @Inject constructor(
+    private val repository: SeriesRepository
+) {
+    suspend operator fun invoke(serisId: Int, ratingValue: Float) {
+        repository.addRating(serisId, ratingValue)
+    }
+}

--- a/presentation/details/src/main/java/com/giraffe/details/screens/seriesdetails/SeriesDetailsViewModel.kt
+++ b/presentation/details/src/main/java/com/giraffe/details/screens/seriesdetails/SeriesDetailsViewModel.kt
@@ -13,13 +13,13 @@ import com.giraffe.details.models.toReviewUI
 import com.giraffe.details.screens.seriesdetails.screen.SeriesDetailsRoute
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.entity.Review
-import com.giraffe.media.movies.usecase.AddMovieRatingUseCase
 import com.giraffe.media.person.entity.Person
 import com.giraffe.media.person.entity.PersonType
 import com.giraffe.media.person.usecase.GetPeopleBySeriesIdUseCase
 import com.giraffe.media.series.entity.Season
 import com.giraffe.media.series.entity.Series
 import com.giraffe.media.series.usecase.AddRecentSeriesUseCase
+import com.giraffe.media.series.usecase.AddSeriesRatingUseCase
 import com.giraffe.media.series.usecase.GetLastSeasonsUseCase
 import com.giraffe.media.series.usecase.GetRecommendedSeriesUseCase
 import com.giraffe.media.series.usecase.GetSeriesDetailsUseCase
@@ -39,7 +39,7 @@ class SeriesDetailsViewModel @Inject constructor(
     private val getSeriesReviews: GetSeriesReviewsUseCase,
     private val storeRecentSeriesUseCase: AddRecentSeriesUseCase,
     private val isLoggedInUseCase: IsLoggedInUseCase,
-    private val addRatingUseCase: AddMovieRatingUseCase,
+    private val addRatingUseCase: AddSeriesRatingUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<SeriesDetailsScreenState, SeriesDetailsEffect>(
     SeriesDetailsScreenState()
@@ -146,7 +146,7 @@ class SeriesDetailsViewModel @Inject constructor(
             if (isLoggedInUseCase()) {
                 updateState { it.copy(isVisibleGiveStarsBottomSheet = false) }
                 addRatingUseCase(
-                    movieId = seriesID,
+                    serisId = seriesID,
                     ratingValue = state.value.currentRating.toFloat()
                 )
             } else {

--- a/presentation/profile/src/main/java/com/giraffe/profile/base/BaseViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/base/BaseViewModel.kt
@@ -1,6 +1,5 @@
 package com.giraffe.profile.base
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.giraffe.media.exception.NoInternetException
@@ -46,7 +45,6 @@ abstract class BaseViewModel<S, E>(initialState: S) : ViewModel() {
                 onSuccess(block())
                 _isNoInternet.update { false }
             } catch (e: Throwable) {
-                Log.d("messi", "safeExecute: $e")
                 if (e is NoInternetException) {
                     _isNoInternet.update { true }
                 } else {

--- a/presentation/profile/src/main/java/com/giraffe/profile/base/BaseViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/base/BaseViewModel.kt
@@ -1,5 +1,6 @@
 package com.giraffe.profile.base
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.giraffe.media.exception.NoInternetException
@@ -38,13 +39,14 @@ abstract class BaseViewModel<S, E>(initialState: S) : ViewModel() {
         onSuccess: (T) -> Unit = {},
         coroutineScope: CoroutineScope = viewModelScope,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
-        block: suspend CoroutineScope.() -> T
+        block: suspend () -> T
     ) {
         coroutineScope.launch(dispatcher) {
             try {
                 onSuccess(block())
                 _isNoInternet.update { false }
             } catch (e: Throwable) {
+                Log.d("messi", "safeExecute: $e")
                 if (e is NoInternetException) {
                     _isNoInternet.update { true }
                 } else {

--- a/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingScreen.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingScreen.kt
@@ -2,11 +2,11 @@ package com.giraffe.profile.screens.ratings
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -70,52 +70,50 @@ private fun RatingContent(
     state: RatingScreenState,
     interaction: RatingInteractionListener
 ) {
-    LazyColumn(
+    Column(
         modifier = modifier
             .background(Theme.color.background.screen)
             .fillMaxSize()
-            .systemBarsPadding()
-            .padding(horizontal = 16.dp),
-        contentPadding = PaddingValues(bottom = 12.dp)
+            .systemBarsPadding(),
     ) {
-        stickyHeader {
-            AppBar(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                title = stringResource(R.string.my_ratings),
-                showBackButton = true,
-                onBackButtonClick = interaction::onBackClick
+        AppBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            title = stringResource(R.string.my_ratings),
+            showBackButton = true,
+            onBackButtonClick = interaction::onBackClick
+        )
+        AnimatedVisibility(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            visible = state.isTipVisible
+        ) {
+            InfoCard(
+                description = stringResource(R.string.tap_an_item_to_see_details_or_update_your_rating),
+                modifier = Modifier.fillMaxWidth(),
+                onClosedClick = interaction::onCloseTipClick
             )
         }
-        item {
-            AnimatedVisibility(
-                visible = state.isTipVisible
-            ) {
-                InfoCard(
-                    description = stringResource(R.string.tap_an_item_to_see_details_or_update_your_rating),
-                    modifier = Modifier.fillMaxWidth(),
-                    onClosedClick = interaction::onCloseTipClick
+        Tabs(
+            listOf(
+                stringResource(R.string.movies),
+                stringResource(R.string.series)
+            ),
+            selectedTabIndex = state.selectedTabIndex,
+            onTabSelected = interaction::onTabSelected,
+        )
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(state.selectedPosters, key = { it.poster.id }) {
+                RatedItem(
+                    ratedPoster = it,
+                    onItemClick = interaction::onPosterClick,
+                    onDeleteClick = interaction::onDeleteRatedPosterClick
                 )
             }
-        }
-        item {
-            Tabs(
-                listOf(
-                    stringResource(R.string.movies),
-                    stringResource(R.string.series)
-                ),
-                selectedTabIndex = state.selectedTabIndex,
-                onTabSelected = interaction::onTabSelected,
-            )
-        }
-        items(state.selectedPosters) {
-            Spacer(modifier = Modifier.height(12.dp))
-            RatedItem(
-                ratedPoster = it,
-                onItemClick = interaction::onPosterClick,
-                onDeleteClick = interaction::onDeleteRatedPosterClick
-            )
         }
     }
 }

--- a/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingViewModel.kt
@@ -13,8 +13,6 @@ import com.giraffe.media.series.usecase.GetSeriesGenresUseCase
 import com.giraffe.profile.base.BaseViewModel
 import com.giraffe.profile.model.RatedPoster
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,102 +27,52 @@ class RatingViewModel @Inject constructor(
     RatingInteractionListener {
 
     init {
-        safeExecute(
-            onSuccess = {
-                getRatedItems()
-            }
-        ) {
-            coroutineScope {
-                val moviesJob = async { getMoviesGenres() }
-                val seriesJob = async { getSeriesGenres() }
-                moviesJob.await()
-                seriesJob.await()
-            }
-        }
-
-        onTabSelected(0)
+        getGenres()
     }
 
-    private fun getRatedItems() {
-        safeExecute {
-            coroutineScope {
-                val ratedMoviesJob = async { getRatedMovies() }
-                val ratedSeriesJob = async { getRatedSeries() }
-                ratedMoviesJob.await()
-                ratedSeriesJob.await()
-            }
-        }
-    }
-
-
-    private fun getMoviesGenres() {
+    private fun getGenres() {
         safeExecute(
             onSuccess = ::onGetMoviesGenresSuccess,
-            onError = ::onGetMoviesGenresFailure
-        ) {
-            getMoviesGenresUseCase()
-        }
+            onError = ::onGetMoviesGenresFailure,
+            block = getMoviesGenresUseCase::invoke
+        )
+        safeExecute(
+            onSuccess = ::onGetSeriesGenresSuccess,
+            onError = ::onGetSeriesGenresFailure,
+            block = getSeriesGenresUseCase::invoke
+        )
     }
 
     private fun onGetMoviesGenresSuccess(genres: List<Genre>) {
-        updateState {
-            it.copy(
-                isLoading = false,
-                movieGenres = genres
-            )
-        }
+        updateState { it.copy(isLoading = false, movieGenres = genres) }
+        safeExecute(
+            onSuccess = ::onGetRatedMoviesSuccess,
+            onError = ::onGetRatedMoviesFailure,
+            block = getRatedMoviesUseCase::invoke
+        )
     }
 
     private fun onGetMoviesGenresFailure(error: Throwable) {
-        updateState {
-            it.copy(
-                isLoading = false
-            )
-        }
-
+        updateState { it.copy(isLoading = false) }
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
-    }
-
-
-    private fun getSeriesGenres() {
-        safeExecute(
-            onSuccess = ::onGetSeriesGenresSuccess,
-            onError = ::onGetSeriesGenresFailure
-        ) {
-            getSeriesGenresUseCase()
-        }
     }
 
     private fun onGetSeriesGenresSuccess(genres: List<Genre>) {
-        updateState {
-            it.copy(
-                isLoading = false,
-                movieGenres = genres
-            )
-        }
+        updateState { it.copy(isLoading = false, seriesGenres = genres) }
+        safeExecute(
+            onSuccess = ::onGetRatedSeriesSuccess,
+            onError = ::onGetRatedSeriesFailure,
+            block = getRatedSeriesUseCase::invoke
+        )
     }
 
     private fun onGetSeriesGenresFailure(error: Throwable) {
-        updateState {
-            it.copy(
-                isLoading = false
-            )
-        }
-
+        updateState { it.copy(isLoading = false) }
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
     }
 
-    private fun getRatedMovies() {
-        safeExecute(
-            onSuccess = ::onGetRatedMoviesSuccess,
-            onError = ::onGetRatedMoviesFailure
-        ) {
-            getRatedMoviesUseCase()
-        }
-    }
-
-    private fun onGetRatedMoviesSuccess(moviesMap: Map<Float, Movie>) {
-        val ratedMovies = moviesMap.entries
+    private fun onGetRatedMoviesSuccess(ratedMovies: Map<Float, Movie>) {
+        val ratedMovies = ratedMovies.entries
             .map {
                 RatedPoster.fromMovie(
                     movie = it.value,
@@ -132,31 +80,16 @@ class RatingViewModel @Inject constructor(
                     genres = state.value.movieGenres
                 )
             }
-
-        if (state.value.selectedTabIndex == 0) {
-            updateState {
-                it.copy(
-                    selectedPosters = ratedMovies,
-                )
-            }
-        }
+        updateState { it.copy(moviesPosters = ratedMovies) }
+        if (state.value.selectedTabIndex == 0) updateState { it.copy(selectedPosters = ratedMovies) }
     }
 
     private fun onGetRatedMoviesFailure(error: Throwable) {
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
     }
 
-    private fun getRatedSeries() {
-        safeExecute(
-            onSuccess = ::onGetRatedSeriesSuccess,
-            onError = ::onGetRatedSeriesFailure
-        ) {
-            getRatedSeriesUseCase()
-        }
-    }
-
-    private fun onGetRatedSeriesSuccess(seriesMap: Map<Float, Series>) {
-        val ratedSeries = seriesMap.entries
+    private fun onGetRatedSeriesSuccess(ratedSeries: Map<Float, Series>) {
+        val ratedSeries = ratedSeries.entries
             .map {
                 RatedPoster.fromSeries(
                     series = it.value,
@@ -164,30 +97,14 @@ class RatingViewModel @Inject constructor(
                     genres = state.value.seriesGenres
                 )
             }
-
-        if (state.value.selectedTabIndex == 1) {
-            updateState {
-                it.copy(
-                    selectedPosters = ratedSeries,
-                )
-            }
-        }
+        updateState { it.copy(seriesPosters = ratedSeries) }
+        if (state.value.selectedTabIndex != 0) updateState { it.copy(selectedPosters = ratedSeries) }
     }
 
     private fun onGetRatedSeriesFailure(error: Throwable) {
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
     }
 
-    override fun onPosterClick(poster: Poster) {
-        if (poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
-            sendEffect(RatingEffect.NavigateToMovieDetails(poster.id))
-        }
-
-        if (poster.mediaTypeOfPoster == Poster.Type.SERIES.value) {
-            sendEffect(RatingEffect.NavigateToSeriesDetails(poster.id))
-        }
-
-    }
 
     override fun onCloseTipClick() {
         updateState { it.copy(isTipVisible = false) }
@@ -206,6 +123,18 @@ class RatingViewModel @Inject constructor(
         }
     }
 
+
+    override fun onPosterClick(poster: Poster) {
+        if (poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
+            sendEffect(RatingEffect.NavigateToMovieDetails(poster.id))
+        }
+
+        if (poster.mediaTypeOfPoster == Poster.Type.SERIES.value) {
+            sendEffect(RatingEffect.NavigateToSeriesDetails(poster.id))
+        }
+
+    }
+
     override fun onDeleteRatedPosterClick(poster: Poster) {
         if (poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
             deleteMovieRating(poster.id)
@@ -218,16 +147,19 @@ class RatingViewModel @Inject constructor(
 
     private fun deleteMovieRating(movieId: Int) {
         safeExecute(
-            onSuccess = ::onDeleteMovieRatingSuccess,
+            onSuccess = { onDeleteMovieRatingSuccess() },
             onError = ::onMovieRatingDeleteFailure
         ) {
             deleteMovieRatingUseCase(movieId)
         }
     }
 
-
-    private fun onDeleteMovieRatingSuccess(result: Unit) {
-        getRatedMovies()
+    private fun onDeleteMovieRatingSuccess() {
+        safeExecute(
+            onSuccess = ::onGetRatedMoviesSuccess,
+            onError = ::onGetRatedMoviesFailure,
+            block = getRatedMoviesUseCase::invoke
+        )
     }
 
     private fun onMovieRatingDeleteFailure(error: Throwable) {
@@ -236,15 +168,19 @@ class RatingViewModel @Inject constructor(
 
     private fun deleteSeriesRating(seriesId: Int) {
         safeExecute(
-            onSuccess = ::onDeleteSeriesRatingSuccess,
+            onSuccess = { onDeleteSeriesRatingSuccess() },
             onError = ::onSeriesRatingDeleteFailure
         ) {
             deleteSeriesRatingUseCase(seriesId)
         }
     }
 
-    private fun onDeleteSeriesRatingSuccess(result: Unit) {
-        getRatedSeries()
+    private fun onDeleteSeriesRatingSuccess() {
+        safeExecute(
+            onSuccess = ::onGetRatedSeriesSuccess,
+            onError = ::onGetRatedSeriesFailure,
+            block = getRatedSeriesUseCase::invoke
+        )
     }
 
     private fun onSeriesRatingDeleteFailure(error: Throwable) {

--- a/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.giraffe.media.series
 import com.giraffe.media.dto.ReviewDto
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.mapper.toEntity
+import com.giraffe.media.movie.datasource.remote.dto.RatingRequest
 import com.giraffe.media.series.datasource.local.SeriesLocalDateSource
 import com.giraffe.media.series.datasource.local.cacheDto.SeriesGenreCacheDto
 import com.giraffe.media.series.datasource.remote.SeriesRemoteDataSource
@@ -140,6 +141,11 @@ class SeriesRepositoryImpl @Inject constructor(
 
     override suspend fun addTopRatedSeries(series: List<Series>) = SafeCall {
         seriesLocalDateSource.insertTopRatedSeries(series.map { it.toCacheDto() })
+    }
+
+    override suspend fun addRating(serisId: Int, ratingValue: Float) = SafeCall {
+        val requestBody = RatingRequest(value = ratingValue)
+        seriesRemoteDataSource.addRating(serisId, requestBody)
     }
 
     override suspend fun deleteSeriesById(seriesId: Int) = SafeCall {

--- a/repository/media/src/main/java/com/giraffe/media/series/datasource/remote/SeriesRemoteDataSource.kt
+++ b/repository/media/src/main/java/com/giraffe/media/series/datasource/remote/SeriesRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.giraffe.media.series.datasource.remote
 
 import com.giraffe.media.dto.ReviewDto
+import com.giraffe.media.movie.datasource.remote.dto.RatingRequest
 import com.giraffe.media.series.datasource.remote.dto.GenreDto
 import com.giraffe.media.series.datasource.remote.dto.SeriesDetailsDto
 import com.giraffe.media.series.datasource.remote.dto.SeriesDto
@@ -22,4 +23,6 @@ interface SeriesRemoteDataSource {
     ): List<SeriesDto>
 
     suspend fun deleteSeriesRating(seriesId: Int)
+
+    suspend fun addRating(serisId: Int, request: RatingRequest)
 }


### PR DESCRIPTION

This commit refactors the rating functionality for both movies and series.

Key changes include:
- Adding `NEEDS_SESSION` header to rating-related API calls.
- Implementing `addRating` in `SeriesRepositoryImpl` and `SeriesRemoteRetrofitDataSourceImp`.
- Creating `AddSeriesRatingUseCase`.
- Updating `RatingViewModel` to handle genre fetching and rated item loading more efficiently, and to correctly update UI after deleting a rating.
- Refactoring `RatingScreen` to use `Column` and `LazyColumn` for better layout and performance.
- Updating `SeriesDetailsViewModel` to use `AddSeriesRatingUseCase` for adding series ratings.
- Adding `SERIES_ID` and `TV_END_POINT` to `NetworkConstants`.
- Adding logging for errors in `BaseViewModel`.