### PR TITLE
feature/539-ratings-screen

### DIFF
--- a/domain/media/src/main/java/com/giraffe/media/movies/entity/Movie.kt
+++ b/domain/media/src/main/java/com/giraffe/media/movies/entity/Movie.kt
@@ -17,5 +17,6 @@ data class Movie(
     val recentViewedAt: Long?,
     val recentReleasedAt: Long?,
     val upcomingAt: Long?,
-    val popularity: Float
+    val popularity: Float,
+    val userRating: Float? = null
 )

--- a/domain/media/src/main/java/com/giraffe/media/movies/repository/MoviesRepository.kt
+++ b/domain/media/src/main/java/com/giraffe/media/movies/repository/MoviesRepository.kt
@@ -38,7 +38,7 @@ interface MoviesRepository {
 
     suspend fun deleteMovieById(movieId: Int)
 
-    suspend fun getRatedMovies(accountId: Int): Map<Float, Movie>
+    suspend fun getRatedMovies(accountId: Int): List<Movie>
 
     suspend fun deleteMovieRating(movieId: Int)
 

--- a/domain/media/src/main/java/com/giraffe/media/movies/usecase/GetRatedMoviesUseCase.kt
+++ b/domain/media/src/main/java/com/giraffe/media/movies/usecase/GetRatedMoviesUseCase.kt
@@ -1,6 +1,5 @@
 package com.giraffe.media.movies.usecase
 
-import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.movies.repository.MoviesRepository
 import com.giraffe.user.usecase.GetUserUseCase
 import javax.inject.Inject
@@ -9,8 +8,5 @@ class GetRatedMoviesUseCase @Inject constructor(
     private val repository: MoviesRepository,
     private val getUserUseCase: GetUserUseCase
 ) {
-    suspend operator fun invoke(): Map<Float, Movie> {
-        val accountId = getUserUseCase().id
-        return repository.getRatedMovies(accountId)
-    }
+    suspend operator fun invoke() = repository.getRatedMovies(getUserUseCase().id)
 }

--- a/domain/media/src/main/java/com/giraffe/media/series/entity/Series.kt
+++ b/domain/media/src/main/java/com/giraffe/media/series/entity/Series.kt
@@ -12,5 +12,6 @@ data class Series(
     val releaseYear: String,
     val seasons: List<Season> = emptyList(),
     val youtubeVideoId: String = "",
-    val popularity: Double = 0.0
+    val popularity: Double = 0.0,
+    val userRating: Float? = null
 )

--- a/domain/media/src/main/java/com/giraffe/media/series/repository/SeriesRepository.kt
+++ b/domain/media/src/main/java/com/giraffe/media/series/repository/SeriesRepository.kt
@@ -28,7 +28,7 @@ interface SeriesRepository {
     suspend fun getRecentlyReleasedSeries(page: Int, limit: Int): List<Series>
     suspend fun addRecentlyReleasedSeries(series: List<Series>)
     suspend fun getTopRatedSeries(page: Int, limit: Int): List<Series>
-    suspend fun getRatedSeries(accountId: Int): Map<Float, Series>
+    suspend fun getRatedSeries(accountId: Int): List<Series>
     suspend fun deleteSeriesRating(seriesId: Int)
     suspend fun deleteSeriesById(seriesId: Int)
     suspend fun addTopRatedSeries(series: List<Series>)

--- a/domain/media/src/main/java/com/giraffe/media/series/usecase/GetRatedSeriesUseCase.kt
+++ b/domain/media/src/main/java/com/giraffe/media/series/usecase/GetRatedSeriesUseCase.kt
@@ -1,6 +1,5 @@
 package com.giraffe.media.series.usecase
 
-import com.giraffe.media.series.entity.Series
 import com.giraffe.media.series.repository.SeriesRepository
 import com.giraffe.user.usecase.GetUserUseCase
 import javax.inject.Inject
@@ -9,8 +8,5 @@ class GetRatedSeriesUseCase @Inject constructor(
     private val repository: SeriesRepository,
     private val getUserUseCase: GetUserUseCase
 ) {
-    suspend operator fun invoke(): Map<Float, Series> {
-        val accountId = getUserUseCase().id
-        return repository.getRatedSeries(accountId)
-    }
+    suspend operator fun invoke() = repository.getRatedSeries(getUserUseCase().id)
 }

--- a/presentation/profile/src/main/java/com/giraffe/profile/components/RatedItem.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/components/RatedItem.kt
@@ -21,15 +21,14 @@ import com.giraffe.designsystem.composable.PosterItemHorizontal
 import com.giraffe.designsystem.composable.custom.Icon
 import com.giraffe.designsystem.composable.custom.Text
 import com.giraffe.designsystem.theme.Theme
-import com.giraffe.designsystem.uimodel.Poster
 import com.giraffe.profile.model.RatedPoster
 
 @Composable
 fun RatedItem(
     modifier: Modifier = Modifier,
     ratedPoster: RatedPoster,
-    onItemClick: (Poster) -> Unit = {},
-    onDeleteClick: (Poster) -> Unit = {}
+    onItemClick: (RatedPoster) -> Unit = {},
+    onDeleteClick: (RatedPoster) -> Unit = {}
 ) {
     Column(
         modifier = Modifier,
@@ -39,19 +38,18 @@ fun RatedItem(
         RateSection(
             modifier = Modifier.fillMaxWidth(),
             rate = ratedPoster.rating.toDouble(),
-            date = ratedPoster.poster.date ?: "--- --, 20--"
         )
         SwipableItem(
             actionButton = {
                 DeleteButton(
-                    onDeleteClick = { onDeleteClick(ratedPoster.poster) }
+                    onDeleteClick = { onDeleteClick(ratedPoster) }
                 )
             },
         ) {
             PosterItemHorizontal(
                 modifier = modifier.fillMaxWidth(),
                 movie = ratedPoster.poster,
-                onClickPoster = { onItemClick(ratedPoster.poster) }
+                onClickPoster = { onItemClick(ratedPoster) }
             )
         }
     }
@@ -80,7 +78,7 @@ fun DeleteButton(modifier: Modifier = Modifier, onDeleteClick: () -> Unit = {}) 
 }
 
 @Composable
-private fun RateSection(modifier: Modifier = Modifier, rate: Double, date: String) {
+private fun RateSection(modifier: Modifier = Modifier, rate: Double) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -97,11 +95,6 @@ private fun RateSection(modifier: Modifier = Modifier, rate: Double, date: Strin
             )
             Stars(rate = rate)
         }
-        Text(
-            text = "on $date",
-            style = Theme.textStyle.body.sm.medium,
-            color = Theme.color.shade.primary
-        )
     }
 }
 

--- a/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingInteractionListener.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingInteractionListener.kt
@@ -1,12 +1,12 @@
 package com.giraffe.profile.screens.ratings
 
-import com.giraffe.designsystem.uimodel.Poster
+import com.giraffe.profile.model.RatedPoster
 
 interface RatingInteractionListener {
-    fun onPosterClick(poster: Poster)
+    fun onPosterClick(ratedPoster: RatedPoster)
     fun onCloseTipClick()
     fun onBackClick()
     fun onTabSelected(tabIndex: Int)
 
-    fun onDeleteRatedPosterClick(poster: Poster)
+    fun onDeleteRatedPosterClick(ratedPoster: RatedPoster)
 }

--- a/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/screens/ratings/RatingViewModel.kt
@@ -12,6 +12,7 @@ import com.giraffe.media.series.usecase.GetRatedSeriesUseCase
 import com.giraffe.media.series.usecase.GetSeriesGenresUseCase
 import com.giraffe.profile.base.BaseViewModel
 import com.giraffe.profile.model.RatedPoster
+import com.giraffe.profile.utils.toRatedPoster
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -71,15 +72,9 @@ class RatingViewModel @Inject constructor(
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
     }
 
-    private fun onGetRatedMoviesSuccess(ratedMovies: Map<Float, Movie>) {
-        val ratedMovies = ratedMovies.entries
-            .map {
-                RatedPoster.fromMovie(
-                    movie = it.value,
-                    rating = it.key,
-                    genres = state.value.movieGenres
-                )
-            }
+    private fun onGetRatedMoviesSuccess(ratedMovies: List<Movie>) {
+        val ratedMovies =
+            ratedMovies.map { it.toRatedPoster(state.value.movieGenres.filter { genres -> genres.id in it.genresID }) }
         updateState { it.copy(moviesPosters = ratedMovies) }
         if (state.value.selectedTabIndex == 0) updateState { it.copy(selectedPosters = ratedMovies) }
     }
@@ -88,15 +83,9 @@ class RatingViewModel @Inject constructor(
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
     }
 
-    private fun onGetRatedSeriesSuccess(ratedSeries: Map<Float, Series>) {
-        val ratedSeries = ratedSeries.entries
-            .map {
-                RatedPoster.fromSeries(
-                    series = it.value,
-                    rating = it.key,
-                    genres = state.value.seriesGenres
-                )
-            }
+    private fun onGetRatedSeriesSuccess(ratedSeries: List<Series>) {
+        val ratedSeries =
+            ratedSeries.map { it.toRatedPoster(state.value.seriesGenres.filter { genres -> genres.id in it.genreIDs }) }
         updateState { it.copy(seriesPosters = ratedSeries) }
         if (state.value.selectedTabIndex != 0) updateState { it.copy(selectedPosters = ratedSeries) }
     }
@@ -124,63 +113,61 @@ class RatingViewModel @Inject constructor(
     }
 
 
-    override fun onPosterClick(poster: Poster) {
-        if (poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
-            sendEffect(RatingEffect.NavigateToMovieDetails(poster.id))
+    override fun onPosterClick(ratedPoster: RatedPoster) {
+        if (ratedPoster.poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
+            sendEffect(RatingEffect.NavigateToMovieDetails(ratedPoster.poster.id))
         }
 
-        if (poster.mediaTypeOfPoster == Poster.Type.SERIES.value) {
-            sendEffect(RatingEffect.NavigateToSeriesDetails(poster.id))
+        if (ratedPoster.poster.mediaTypeOfPoster == Poster.Type.SERIES.value) {
+            sendEffect(RatingEffect.NavigateToSeriesDetails(ratedPoster.poster.id))
         }
 
     }
 
-    override fun onDeleteRatedPosterClick(poster: Poster) {
-        if (poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
-            deleteMovieRating(poster.id)
+    override fun onDeleteRatedPosterClick(ratedPoster: RatedPoster) {
+        if (ratedPoster.poster.mediaTypeOfPoster == Poster.Type.MOVIE.value) {
+            deleteMovieRating(ratedPoster)
         }
 
-        if (poster.mediaTypeOfPoster == Poster.Type.SERIES.value) {
-            deleteSeriesRating(poster.id)
+        if (ratedPoster.poster.mediaTypeOfPoster == Poster.Type.SERIES.value) {
+            deleteSeriesRating(ratedPoster)
         }
     }
 
-    private fun deleteMovieRating(movieId: Int) {
+    private fun deleteMovieRating(ratedPoster: RatedPoster) {
         safeExecute(
-            onSuccess = { onDeleteMovieRatingSuccess() },
+            onSuccess = { onDeleteMovieRatingSuccess(ratedPoster) },
             onError = ::onMovieRatingDeleteFailure
         ) {
-            deleteMovieRatingUseCase(movieId)
+            deleteMovieRatingUseCase(ratedPoster.poster.id)
         }
     }
 
-    private fun onDeleteMovieRatingSuccess() {
-        safeExecute(
-            onSuccess = ::onGetRatedMoviesSuccess,
-            onError = ::onGetRatedMoviesFailure,
-            block = getRatedMoviesUseCase::invoke
-        )
+    private fun onDeleteMovieRatingSuccess(ratedPoster: RatedPoster) {
+        (state.value.moviesPosters - ratedPoster).let { moviesPosters ->
+            updateState { it.copy(moviesPosters = moviesPosters) }
+            if (state.value.selectedTabIndex == 0) updateState { it.copy(selectedPosters = moviesPosters) }
+        }
     }
 
     private fun onMovieRatingDeleteFailure(error: Throwable) {
         sendEffect(RatingEffect.ShowError(mapErrorToResource(error)))
     }
 
-    private fun deleteSeriesRating(seriesId: Int) {
+    private fun deleteSeriesRating(ratedPoster: RatedPoster) {
         safeExecute(
-            onSuccess = { onDeleteSeriesRatingSuccess() },
+            onSuccess = { onDeleteSeriesRatingSuccess(ratedPoster) },
             onError = ::onSeriesRatingDeleteFailure
         ) {
-            deleteSeriesRatingUseCase(seriesId)
+            deleteSeriesRatingUseCase(ratedPoster.poster.id)
         }
     }
 
-    private fun onDeleteSeriesRatingSuccess() {
-        safeExecute(
-            onSuccess = ::onGetRatedSeriesSuccess,
-            onError = ::onGetRatedSeriesFailure,
-            block = getRatedSeriesUseCase::invoke
-        )
+    private fun onDeleteSeriesRatingSuccess(ratedPoster: RatedPoster) {
+        (state.value.seriesPosters - ratedPoster).let { seriesPosters ->
+            updateState { it.copy(seriesPosters = seriesPosters) }
+            if (state.value.selectedTabIndex != 0) updateState { it.copy(selectedPosters = seriesPosters) }
+        }
     }
 
     private fun onSeriesRatingDeleteFailure(error: Throwable) {

--- a/presentation/profile/src/main/java/com/giraffe/profile/utils/Mapper.kt
+++ b/presentation/profile/src/main/java/com/giraffe/profile/utils/Mapper.kt
@@ -1,19 +1,19 @@
 package com.giraffe.profile.utils
 
 import com.giraffe.designsystem.uimodel.Poster
+import com.giraffe.media.entity.Genre
 import com.giraffe.media.movies.entity.Movie
 import com.giraffe.media.series.entity.Series
+import com.giraffe.profile.model.RatedPoster
 import com.giraffe.profile.screens.history.HistoryUiModel
 import com.giraffe.profile.screens.history.MediaType
-
-
 
 
 fun Movie.toHistoryUiModel(): HistoryUiModel {
     return HistoryUiModel(
         id = id,
         title = title,
-        posterUrl = posterUrl .orEmpty(),
+        posterUrl = posterUrl.orEmpty(),
         rating = rating,
         mediaType = MediaType.MOVIE
     )
@@ -29,22 +29,34 @@ fun Series.toHistoryUiModel(): HistoryUiModel {
     )
 }
 
-fun Series.toPosterUi(): Poster {
+fun Series.toRatedPoster(genres: List<Genre>) = RatedPoster(
+    poster = this.toPosterUi(genres),
+    rating = userRating ?: 0f,
+)
+
+fun Series.toPosterUi(genres: List<Genre> = emptyList()): Poster {
     return Poster(
         id = id,
         name = name,
+        genres = genres.joinToString(", ") { it.title },
         imageUri = posterUrl,
         rating = rating,
         date = releaseYear,
-        mediaTypeOfPoster ="series"
+        mediaTypeOfPoster = "series"
     )
 }
 
-fun Movie.toPosterUi(): Poster {
+fun Movie.toRatedPoster(genres: List<Genre>) = RatedPoster(
+    poster = this.toPosterUi(genres),
+    rating = userRating ?: 0f,
+)
+
+fun Movie.toPosterUi(genres: List<Genre> = emptyList()): Poster {
     return Poster(
         id = id,
         name = title,
-        imageUri = posterUrl .orEmpty(),
+        genres = genres.joinToString(", ") { it.title },
+        imageUri = posterUrl.orEmpty(),
         rating = rating,
         date = releaseYear.toString(),
         mediaTypeOfPoster = "movie"

--- a/repository/media/src/main/java/com/giraffe/media/movie/MoviesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/MoviesRepositoryImpl.kt
@@ -180,10 +180,8 @@ class MoviesRepositoryImpl @Inject constructor(
         local.deleteMovieById(movieId)
     }
 
-    override suspend fun getRatedMovies(accountId: Int): Map<Float, Movie> = SafeCall {
-        remote.getRatedMovies(accountId)
-            .filter { it.userRating != null }
-            .associate { it.userRating!! to it.toEntity() }
+    override suspend fun getRatedMovies(accountId: Int) = SafeCall {
+        remote.getRatedMovies(accountId).map(MovieDto::toEntity)
     }
 
     override suspend fun deleteMovieRating(movieId: Int) = SafeCall {

--- a/repository/media/src/main/java/com/giraffe/media/movie/mapper/Mapper.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/mapper/Mapper.kt
@@ -97,5 +97,6 @@ fun MovieDto.toEntity(
     recentViewedAt = recentViewedAt,
     recentReleasedAt = recentReleasedAt,
     upcomingAt = upcomingAt,
-    popularity = popularity ?: 0f
+    popularity = popularity ?: 0f,
+    userRating = userRating
 )

--- a/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
@@ -173,10 +173,8 @@ class SeriesRepositoryImpl @Inject constructor(
         seriesLocalDateSource.insertRecommendedSeries(series.map { it.toCacheDto() })
     }
 
-    override suspend fun getRatedSeries(accountId: Int): Map<Float, Series> = SafeCall {
-        seriesRemoteDataSource.getRatedSeries(accountId)
-            .filter { it.userRating != null }
-            .associate { it.userRating!! to it.toEntity() }
+    override suspend fun getRatedSeries(accountId: Int) = SafeCall {
+        seriesRemoteDataSource.getRatedSeries(accountId).map(SeriesDto::toEntity)
     }
 
     override suspend fun deleteSeriesRating(seriesId: Int) = SafeCall {

--- a/repository/media/src/main/java/com/giraffe/media/series/mapper/Mapper.kt
+++ b/repository/media/src/main/java/com/giraffe/media/series/mapper/Mapper.kt
@@ -107,7 +107,8 @@ fun SeriesDto.toEntity() = Series(
     genreIDs = genreIds,
     releaseYear = firstAirDate?.toFormattedDate() ?: "",
     popularity = popularity ?: 0.0,
-    seasons = emptyList()
+    seasons = emptyList(),
+    userRating = userRating
 )
 
 fun GenreDto.toEntity() = Genre(


### PR DESCRIPTION

This PR refactors the way rated movies and series are handled throughout the application.

Key changes:
- Modified `GetRatedMoviesUseCase` and `GetRatedSeriesUseCase` to return `List<Movie>` and `List<Series>` respectively, instead of `Map<Float, Type>`.
- Updated `MoviesRepository` and `SeriesRepository` interfaces and their implementations to reflect the above change.
- Added `userRating` field to `Movie` and `Series` domain entities.
- Updated `SeriesDto.toEntity()` and `MovieDto.toEntity()` mappers to include `userRating`.
- In `RatingViewModel`:
    - Adjusted logic for fetching and displaying rated movies and series to work with the new list format.
    - Updated `onDeleteRatedPosterClick`, `deleteMovieRating`, and `deleteSeriesRating` to remove items locally from the state after successful deletion, instead of re-fetching the entire list.
- Created `toRatedPoster` extension functions in `presentation/profile/src/main/java/com/giraffe/profile/utils/Mapper.kt` for `Movie` and `Series` to simplify mapping to `RatedPoster`.
- Updated `RatedItem` composable and its interaction listener to use `RatedPoster` directly.
- Removed the display of the rating date in `RateSection` within `RatedItem`.