### PR TITLE
Fixhot/Add Keep and Serializable annotations to ShowMoreSectionType

### DIFF
--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/show_more/ShowMoreRoute.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/show_more/ShowMoreRoute.kt
@@ -1,6 +1,7 @@
 package com.giraffe.presentation.home.screen.show_more
 
 import android.content.Context
+import androidx.annotation.Keep
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -12,7 +13,8 @@ data class ShowMoreRoute(
     val sectionType: ShowMoreSectionType
 )
 
-
+@Keep
+@Serializable
 enum class ShowMoreSectionType{
     RECENTLY_RELEASED,
     TOP_RATED_TV_SHOWS,


### PR DESCRIPTION
The `@Keep` annotation ensures that the enum class is not removed or renamed during code obfuscation by ProGuard or R8. The `@Serializable` annotation enables the enum class to be serialized and deserialized, which is necessary for passing it as a navigation argument.