### PR TITLE
Refactor: Implement retry limit for CacheCleanupWorker

### DIFF
--- a/app/src/main/java/com/giraffe/cineverseapp/worker/CacheCleanupWorker.kt
+++ b/app/src/main/java/com/giraffe/cineverseapp/worker/CacheCleanupWorker.kt
@@ -23,7 +23,15 @@ class CacheCleanupWorker @AssistedInject constructor(
             clearSeriesCacheUseCase()
             Result.success()
         } catch (_: Exception) {
-            Result.retry()
+            if (runAttemptCount < MAX_RETRY_ATTEMPTS) {
+                Result.retry()
+            } else {
+                Result.failure()
+            }
         }
+    }
+
+    companion object {
+        private const val MAX_RETRY_ATTEMPTS = 3
     }
 }


### PR DESCRIPTION
The `CacheCleanupWorker` will now retry up to a maximum of 3 times in case of failure. If it still fails after 3 attempts, it will mark the work as failed.