### PR TITLE
Fix poster genres in history and discover screens

### DIFF
--- a/presentation/explore/src/main/java/com/giraffe/presentation/explore/screen/discover/DiscoverScreen.kt
+++ b/presentation/explore/src/main/java/com/giraffe/presentation/explore/screen/discover/DiscoverScreen.kt
@@ -107,22 +107,19 @@ fun ExploreContent(
                     }
 
                     else -> {
-
-                        posters.itemSnapshotList.items.forEach { poster ->
-                            item(key = poster.id) {
-                                GenresAndCardsSection(
-                                    modifier = Modifier.fillParentMaxHeight(),
-                                    onPosterClicked = { id ->
-                                        interactions.onPosterClick(id, state.selectedTab)
-                                    },
-                                    posters = posters,
-                                    selectedGenre = state.selectedGenre
-                                        ?: GenreUi(title = stringResource(R.string.all)),
-                                    genres = listOf(GenreUi(title = stringResource(R.string.all))) + state.selectedGenres,
-                                    isGridSelected = state.isGridSelected,
-                                    onGenreSelected = interactions::onGenreSelected,
-                                )
-                            }
+                        item {
+                            GenresAndCardsSection(
+                                modifier = Modifier.fillParentMaxHeight(),
+                                onPosterClicked = { id ->
+                                    interactions.onPosterClick(id, state.selectedTab)
+                                },
+                                posters = posters,
+                                selectedGenre = state.selectedGenre
+                                    ?: GenreUi(title = stringResource(R.string.all)),
+                                genres = listOf(GenreUi(title = stringResource(R.string.all))) + state.selectedGenres,
+                                isGridSelected = state.isGridSelected,
+                                onGenreSelected = interactions::onGenreSelected,
+                            )
                         }
                     }
 

--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/history/HistoryViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/history/HistoryViewModel.kt
@@ -79,11 +79,11 @@ class HistoryViewModel @Inject constructor(
     }
 
     private fun onGetRecentMoviesSuccess(moviesList: List<Movie>) {
-        updateMediaList(moviesList.map { movie -> movie.toPoster(state.value.moviesGenres) })
+        updateMediaList(moviesList.map { movie -> movie.toPoster(state.value.moviesGenres.filter { it.id in movie.genresID }) })
     }
 
     private fun onGetRecentSeriesSuccess(seriesList: List<Series>) {
-        updateMediaList(seriesList.map { series -> series.toPoster(state.value.seriesGenres) })
+        updateMediaList(seriesList.map { series -> series.toPoster(state.value.seriesGenres.filter { it.id in series.genreIDs }) })
     }
 
     private fun updateMediaList(newMediaList: List<Poster>) {


### PR DESCRIPTION
The `HistoryViewModel` was updated to correctly filter movie and series genres.
The `DiscoverScreen` was updated to ensure that the `GenresAndCardsSection` is recomposed only when necessary.