### PR TITLE
Refactor: Observe movie genres and improve data loading

### DIFF
--- a/datasource/local/media/src/main/java/com/giraffe/media/movie/MovieLocalDataSourceImpl.kt
+++ b/datasource/local/media/src/main/java/com/giraffe/media/movie/MovieLocalDataSourceImpl.kt
@@ -11,6 +11,8 @@ import com.giraffe.media.movie.mapper.toRecentlyViewedMovieCacheDto
 import com.giraffe.media.movie.mapper.toUpcomingMovieCacheDto
 import com.giraffe.media.util.safeCall
 import com.giraffe.media.util.safeFlow
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
 import javax.inject.Inject
 
 
@@ -37,8 +39,9 @@ class MovieLocalDataSourceImpl @Inject constructor(
     override fun getMovieGenresByIds(ids: List<Int>) =
         safeFlow { movieDao.getMovieGenresByIds(ids) }
 
+    @OptIn(FlowPreview::class)
     override fun getMoviesGenres() =
-        safeFlow { movieDao.getMoviesGenres() }
+        safeFlow { movieDao.getMoviesGenres() }.debounce(1000L)
 
     override suspend fun getTopGenre() =
         safeCall { movieDao.getTopGenre() }

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeScreenState.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeScreenState.kt
@@ -1,5 +1,6 @@
 package com.giraffe.presentation.home.screen.home
 
+import com.giraffe.media.entity.Genre
 import com.giraffe.presentation.home.model.FeaturedCollectionType
 import com.giraffe.presentation.home.model.FeaturedCollectionUi
 import com.giraffe.presentation.home.model.PopularMediaUi
@@ -28,4 +29,6 @@ data class HomeScreenState(
     val isLoadingTopRatedSeries: Boolean = true,
     val isNoInternet: Boolean = false,
     val isLoggedIn: Boolean = false,
+    val moviesGenres: List<Genre> = emptyList(),
+    val seriesGenres: List<Genre> = emptyList()
 )

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
@@ -3,10 +3,11 @@ package com.giraffe.presentation.home.screen.home
 import androidx.lifecycle.viewModelScope
 import com.giraffe.media.collections.entity.Collection
 import com.giraffe.media.collections.usecase.GetCollectionsUseCase
+import com.giraffe.media.entity.Genre
 import com.giraffe.media.exception.NoInternetException
 import com.giraffe.media.movie.entity.Movie
 import com.giraffe.media.movie.usecase.ObservePopularMoviesUseCase
-import com.giraffe.media.movie.usecase.genre.GetMoviesGenresByIdsUseCase
+import com.giraffe.media.movie.usecase.genre.ObserveMoviesGenresUseCase
 import com.giraffe.media.movie.usecase.matchesYourVibe.ObserveMatchesYourVibeMoviesUseCase
 import com.giraffe.media.movie.usecase.recentlyReleased.ObserveRecentlyReleasedMoviesUseCase
 import com.giraffe.media.movie.usecase.recentlyViewed.ObserveRecentlyViewedMoviesUseCase
@@ -41,18 +42,19 @@ class HomeViewModel @Inject constructor(
     private val observeTopRatedSeriesUseCase: ObserveTopRatedSeriesUseCase,
     private val observeUpcomingMoviesUseCase: ObserveUpcomingMoviesUseCase,
     private val getSeriesGenresByIdsUseCase: GetSeriesGenresByIdsUseCase,
-    private val getMoviesGenresByIdsUseCase: GetMoviesGenresByIdsUseCase,
     private val observeRecentlyViewedMoviesUseCase: ObserveRecentlyViewedMoviesUseCase,
     private val observeRecentlyViewedSeriesUseCase: ObserveRecentlyViewedSeriesUseCase,
     private val observeMatchesYourVibeMoviesUseCase: ObserveMatchesYourVibeMoviesUseCase,
     private val observeMatchesYourVibeSeriesUseCase: ObserveMatchesYourVibeSeriesUseCase,
     private val getCollectionsUseCase: GetCollectionsUseCase,
     private val getUserNameUseCase: GetUserNameUseCase,
-    private val isLoggedInByAccountUseCase: IsLoggedInByAccountUseCase
+    private val isLoggedInByAccountUseCase: IsLoggedInByAccountUseCase,
+    private val observeMoviesGenresUseCase: ObserveMoviesGenresUseCase
 ) : BaseViewModel<HomeScreenState, HomeEffect>(initialState = HomeScreenState()),
     HomeInteractionListener {
 
     init {
+
         loadHomeScreenData()
     }
 
@@ -69,14 +71,30 @@ class HomeViewModel @Inject constructor(
             )
         }
         isLoggedIn()
-        getPopularity()
+        getUserName()
+        getYourCollections()
+
+        getMoviesGenres()
+
         getRecentlyReleased()
         getUpcomingMovies()
         getMatchesYourVibe()
         getTopRatedSeries()
         getRecentViewed()
-        getUserName()
-        getYourCollections()
+
+    }
+
+    private fun getMoviesGenres() {
+        safeCollect(
+            onEmitNewValue = ::onGetMoviesGenresSuccess,
+            onError = ::onError.also { getPopularity() },
+            block = observeMoviesGenresUseCase::invoke
+        )
+    }
+
+    private fun onGetMoviesGenresSuccess(genres: List<Genre>) {
+        updateState { it.copy(moviesGenres = genres) }
+        getPopularity()
     }
 
     private fun isLoggedIn() {
@@ -121,32 +139,25 @@ class HomeViewModel @Inject constructor(
 
 
     private fun getPopularity() {
-        viewModelScope.launch(Dispatchers.IO) {
-            safeCollect(
-                onEmitNewValue = ::onGetPopularityMoviesSuccess,
-                onError = ::onError,
-                block = observePopularMoviesUseCase::invoke
-            )
-            safeCollect(
-                onEmitNewValue = ::onGetPopularitySeriesSuccess,
-                onError = ::onError,
-                block = observePopularSeriesUseCase::invoke
-            )
-        }
+        safeCollect(
+            onEmitNewValue = ::onGetPopularityMoviesSuccess,
+            onError = ::onError,
+            block = observePopularMoviesUseCase::invoke
+        )
+        safeCollect(
+            onEmitNewValue = ::onGetPopularitySeriesSuccess,
+            onError = ::onError,
+            block = observePopularSeriesUseCase::invoke
+        )
     }
 
     private fun onGetPopularityMoviesSuccess(movies: List<Movie>) {
-        safeExecute {
-            val popularMoviesUi = movies.map { movie ->
-                val genres = getMoviesGenresByIdsUseCase(movie.genresID).map { it.title }
-                movie.toPopularMediaUi(genres)
-            }
-            updateState { currentState ->
-                currentState.copy(
-                    popularity = (popularMoviesUi + currentState.popularity).distinctBy { it.id },
-                    isLoadingPopularity = false
-                )
-            }
+        updateState {
+            val newMovies = movies.map { movie -> movie.toPopularMediaUi(it.moviesGenres) }
+            it.copy(
+                popularity = (newMovies + it.popularity).distinctBy { movie -> movie.id },
+                isLoadingPopularity = false
+            )
         }
     }
 

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/utils/Mapper.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/utils/Mapper.kt
@@ -1,6 +1,7 @@
 package com.giraffe.presentation.home.utils
 
 import com.giraffe.media.collections.entity.Collection
+import com.giraffe.media.entity.Genre
 import com.giraffe.media.movie.entity.Movie
 import com.giraffe.media.series.entity.Series
 import com.giraffe.presentation.home.model.MediaType
@@ -55,12 +56,14 @@ fun Movie.toShowMorePoster(genres: List<String>) = PosterMedia(
 )
 
 
-fun Movie.toPopularMediaUi(genres: List<String>) = PopularMediaUi(
+fun Movie.toPopularMediaUi(genres: List<Genre>) = PopularMediaUi(
     id = id,
     title = name,
     posterUrl = posterUrl,
     backdropUrl = backdropUrl,
-    genres = genres,
+    genres = genres
+        .filter { genre -> genre.id in genresID }
+        .map { genre -> genre.title },
     rating = rating,
     mediaType = MediaType.MOVIE
 )

--- a/repository/media/src/main/java/com/giraffe/media/movie/MovieRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/MovieRepositoryImpl.kt
@@ -99,11 +99,6 @@ class MovieRepositoryImpl @Inject constructor(
         return safeFlow {
             movieLocal.getMoviesGenres()
                 .map { it.map(MovieGenreCacheDto::toEntity) }
-                .onEach {
-                    it.ifEmpty {
-                        getGenres()
-                    }
-                }
         }
     }
 


### PR DESCRIPTION

- Modify `MovieRepositoryImpl` to remove `onEach` block when fetching movie genres.
- Add debounce to `getMoviesGenres` in `MovieLocalDataSourceImpl`.
- Update `HomeViewModel` to observe movie genres and use them to populate popular movies.
- Adjust `Mapper.kt` to use `List<Genre>` instead of `List<String>` for movie genres.
- Add `moviesGenres` and `seriesGenres` to `HomeScreenState`.