### PR TITLE
refactor/790-loading-in-home-screen-sections

### DIFF
--- a/datasource/local/media/src/main/java/com/giraffe/media/movie/MovieLocalDataSourceImpl.kt
+++ b/datasource/local/media/src/main/java/com/giraffe/media/movie/MovieLocalDataSourceImpl.kt
@@ -41,7 +41,7 @@ class MovieLocalDataSourceImpl @Inject constructor(
 
     @OptIn(FlowPreview::class)
     override fun getMoviesGenres() =
-        safeFlow { movieDao.getMoviesGenres() }.debounce(1000L)
+        safeFlow { movieDao.getMoviesGenres() }.debounce(500L)
 
     override suspend fun getTopGenre() =
         safeCall { movieDao.getTopGenre() }

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/components/ListSection.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/components/ListSection.kt
@@ -1,5 +1,6 @@
 package com.giraffe.presentation.home.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -10,22 +11,28 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.giraffe.designsystem.composable.Rating
 import com.giraffe.designsystem.composable.SectionTitle
+import com.giraffe.designsystem.composable.button_type.PrimaryButton
 import com.giraffe.designsystem.composable.custom.Text
 import com.giraffe.designsystem.theme.Theme
 import com.giraffe.imageviewer.component.SafeIslamicImage
+import com.giraffe.presentation.home.R
 import com.giraffe.presentation.home.model.MediaType
 import com.giraffe.presentation.home.model.Poster
 import com.giraffe.presentation.home.utils.shimmerEffect
@@ -38,6 +45,8 @@ fun ListSection(
     endText: String? = null,
     paddingHorizontal: Int = 16,
     isLoading: Boolean = false,
+    hasError: Boolean = false,
+    onRetry: () -> Unit = {},
     onClickEndText: () -> Unit = {},
     onClickItem: (id: Int, mediaType: MediaType) -> Unit = { _, _ -> }
 ) {
@@ -51,7 +60,7 @@ fun ListSection(
             clickableText = if (posters.size >= 10) endText else null,
             onClickableText = onClickEndText
         )
-        if (isLoading) {
+        if (isLoading && !hasError) {
             LazyRow(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 contentPadding = PaddingValues(horizontal = paddingHorizontal.dp)
@@ -75,6 +84,33 @@ fun ListSection(
                     }
                 }
             }
+        } else if (hasError) {
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(horizontal = paddingHorizontal.dp)
+            ) {
+                item {
+                    RetryCard(onRetry = onRetry)
+                }
+                items(5) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Box(
+                            modifier = Modifier
+                                .height(182.dp)
+                                .clip(RoundedCornerShape(Theme.radius.lg))
+                                .shimmerEffect(isAnimated = false)
+                                .aspectRatio(0.74f),
+                        )
+                        Box(
+                            modifier = Modifier
+                                .height(12.dp)
+                                .width(96.dp)
+                                .clip(RoundedCornerShape(Theme.radius.lg))
+                                .shimmerEffect(isAnimated = false),
+                        )
+                    }
+                }
+            }
         } else {
             LazyRow(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -89,7 +125,6 @@ fun ListSection(
                 }
             }
         }
-
     }
 }
 
@@ -136,6 +171,45 @@ fun HomeItemVertically(
             color = Theme.color.shade.secondary,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+
+@Composable
+fun RetryCard(modifier: Modifier = Modifier, onRetry: () -> Unit) {
+    Column(
+        modifier = modifier
+            .height(182.dp)
+            .clip(RoundedCornerShape(Theme.radius.lg))
+            .aspectRatio(0.74f),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Box(
+            modifier = Modifier.background(
+                color = Theme.color.additional.secondary.red,
+                shape = CircleShape
+            ),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                modifier = Modifier
+                    .size(20.dp)
+                    .padding(14.dp),
+                painter = painterResource(Theme.icons.dueTone.station),
+                contentDescription = stringResource(
+                    R.string.oops_no_internet
+                )
+            )
+        }
+        Text(
+            text = stringResource(R.string.failed_to_load_the_list),
+            style = Theme.textStyle.body.md.medium,
+            color = Theme.color.shade.primary
+        )
+        PrimaryButton(
+            text = stringResource(R.string.try_again),
+            onClick = onRetry
         )
     }
 }

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeInteractionListener.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeInteractionListener.kt
@@ -20,4 +20,10 @@ interface HomeInteractionListener {
     fun onCollectionClick(collectionId: Int, collectionName: String)
 
     fun onFeaturesCollectionClicked(sectionType: CategoryMediaSectionType)
+
+    fun getRecentlyReleased()
+    fun getRecentlyViewed()
+    fun getMatchesYourVibe()
+    fun getUpcoming()
+    fun getTopRated()
 }

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeScreen.kt
@@ -117,6 +117,8 @@ fun HomeContent(
                 endText = stringResource(R.string.show_more),
                 posters = state.recentlyReleased,
                 isLoading = state.isLoadingRecentlyReleased,
+                hasError = state.hasRecentlyReleasedError,
+                onRetry = interactionListener::getRecentlyReleased,
                 onClickItem = interactionListener::onMediaClicked,
                 onClickEndText = {
                     interactionListener.onSeeMoreClicked(
@@ -141,7 +143,9 @@ fun HomeContent(
                 title = stringResource(R.string.upcoming_movies),
                 endText = stringResource(R.string.show_more),
                 posters = state.upcomingMovies,
-                isLoading = state.isLoadingUpcomingMovies,
+                isLoading = state.isLoadingUpcoming,
+                hasError = state.hasUpcomingError,
+                onRetry = interactionListener::getUpcoming,
                 onClickItem = interactionListener::onMediaClicked,
                 onClickEndText = {
                     interactionListener.onSeeMoreClicked(
@@ -149,21 +153,25 @@ fun HomeContent(
                     )
                 }
             )
-            ListSection(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
-                title = stringResource(R.string.matches_your_vibe),
-                endText = stringResource(R.string.show_more),
-                posters = state.matchVibes,
-                isLoading = state.isLoadingMatchesYourVibe,
-                onClickItem = interactionListener::onMediaClicked,
-                onClickEndText = {
-                    interactionListener.onSeeMoreClicked(
-                        sectionType = CategoryMediaSectionType.MATCHES_YOUR_VIBES
-                    )
-                }
-            )
+            AnimatedVisibility(state.isLoadingMatchesYourVibe || state.hasMatchesYourVibeError || state.matchVibes.isNotEmpty()) {
+                ListSection(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    title = stringResource(R.string.matches_your_vibe),
+                    endText = stringResource(R.string.show_more),
+                    posters = state.matchVibes,
+                    isLoading = state.isLoadingMatchesYourVibe,
+                    hasError = state.hasMatchesYourVibeError,
+                    onRetry = interactionListener::getMatchesYourVibe,
+                    onClickItem = interactionListener::onMediaClicked,
+                    onClickEndText = {
+                        interactionListener.onSeeMoreClicked(
+                            sectionType = CategoryMediaSectionType.MATCHES_YOUR_VIBES
+                        )
+                    }
+                )
+            }
             CollectionListSection(
                 modifier = Modifier.padding(vertical = 16.dp),
                 collectionItems = state.featuredCollections,
@@ -176,7 +184,9 @@ fun HomeContent(
                 title = stringResource(R.string.top_rated_tv_shows),
                 endText = stringResource(R.string.show_more),
                 posters = state.topRated,
-                isLoading = state.isLoadingTopRatedSeries,
+                isLoading = state.isLoadingTopRated,
+                hasError = state.hasTopRatedError,
+                onRetry = interactionListener::getTopRated,
                 onClickItem = interactionListener::onMediaClicked,
                 onClickEndText = {
                     interactionListener.onSeeMoreClicked(
@@ -184,21 +194,25 @@ fun HomeContent(
                     )
                 }
             )
-            ListSection(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
-                endText = stringResource(R.string.show_more),
-                title = stringResource(R.string.you_recent_viewed),
-                posters = state.recentlyViewed,
-                isLoading = state.isLoadingRecentlyViewed,
-                onClickItem = interactionListener::onMediaClicked,
-                onClickEndText = {
-                    interactionListener.onSeeMoreClicked(
-                        sectionType = CategoryMediaSectionType.RECENTLY_VIEWED
-                    )
-                }
-            )
+            AnimatedVisibility(state.isLoadingRecentlyViewed || state.hasRecentlyViewedError || state.recentlyViewed.isNotEmpty()) {
+                ListSection(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    endText = stringResource(R.string.show_more),
+                    title = stringResource(R.string.you_recent_viewed),
+                    posters = state.recentlyViewed,
+                    isLoading = state.isLoadingRecentlyViewed,
+                    hasError = state.hasRecentlyViewedError,
+                    onRetry = interactionListener::getRecentlyViewed,
+                    onClickItem = interactionListener::onMediaClicked,
+                    onClickEndText = {
+                        interactionListener.onSeeMoreClicked(
+                            sectionType = CategoryMediaSectionType.RECENTLY_VIEWED
+                        )
+                    }
+                )
+            }
             AnimatedVisibility(state.yourCollections.isNotEmpty()) {
                 YourCollectionsSections(
                     modifier = Modifier.padding(vertical = 16.dp),

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeScreenState.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeScreenState.kt
@@ -7,9 +7,10 @@ import com.giraffe.presentation.home.model.PopularMediaUi
 import com.giraffe.presentation.home.model.Poster
 import com.giraffe.presentation.home.model.YourCollectionUi
 
-
 data class HomeScreenState(
     val userName: String = "",
+    val moviesGenres: List<Genre> = emptyList(),
+    val seriesGenres: List<Genre> = emptyList(),
     val matchVibes: List<Poster> = emptyList(),
     val popularity: List<PopularMediaUi> = emptyList(),
     val recentlyReleased: List<Poster> = emptyList(),
@@ -27,11 +28,13 @@ data class HomeScreenState(
     val isLoadingRecentlyReleased: Boolean = true,
     val isLoadingMatchesYourVibe: Boolean = true,
     val isLoadingRecentlyViewed: Boolean = true,
-    val isLoadingUpcomingMovies: Boolean = true,
-    val isLoadingTopRatedSeries: Boolean = true,
+    val isLoadingUpcoming: Boolean = true,
+    val isLoadingTopRated: Boolean = true,
 
-
-    val isNoInternet: Boolean = false,
-    val moviesGenres: List<Genre> = emptyList(),
-    val seriesGenres: List<Genre> = emptyList()
+    val hasPopularityError: Boolean = false,
+    val hasRecentlyReleasedError: Boolean = false,
+    val hasMatchesYourVibeError: Boolean = false,
+    val hasRecentlyViewedError: Boolean = false,
+    val hasUpcomingError: Boolean = false,
+    val hasTopRatedError: Boolean = false,
 )

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
@@ -1,10 +1,8 @@
 package com.giraffe.presentation.home.screen.home
 
-import androidx.lifecycle.viewModelScope
 import com.giraffe.media.collections.entity.Collection
 import com.giraffe.media.collections.usecase.GetCollectionsUseCase
 import com.giraffe.media.entity.Genre
-import com.giraffe.media.exception.NoInternetException
 import com.giraffe.media.movie.entity.Movie
 import com.giraffe.media.movie.usecase.ObservePopularMoviesUseCase
 import com.giraffe.media.movie.usecase.genre.ObserveMoviesGenresUseCase
@@ -29,9 +27,6 @@ import com.giraffe.presentation.home.utils.toUi
 import com.giraffe.user.usecase.GetUserNameUseCase
 import com.giraffe.user.usecase.IsLoggedInByAccountUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -57,9 +52,9 @@ class HomeViewModel @Inject constructor(
         getUserName()
         getMoviesGenres()
         getRecentlyReleased()
-        getUpcomingMovies()
+        getUpcoming()
         getYourCollections()
-        getTopRatedSeries()
+        getTopRated()
         getMatchesYourVibe()
         getRecentlyViewed()
     }
@@ -69,7 +64,6 @@ class HomeViewModel @Inject constructor(
             onSuccess = {
                 if (it) safeCollect(
                     onEmitNewValue = ::onGetUseNameSuccess,
-                    onError = ::onError,
                     block = getUserNameUseCase::invoke
                 )
             },
@@ -82,7 +76,7 @@ class HomeViewModel @Inject constructor(
     private fun getMoviesGenres() {
         safeCollect(
             onEmitNewValue = ::onGetMoviesGenresSuccess,
-            onError = ::onError.also { getPopularity() },
+            onError = { getPopularity() },
             block = observeMoviesGenresUseCase::invoke
         )
     }
@@ -93,15 +87,29 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun getPopularity() {
-        updateState { it.copy(isLoadingPopularity = true) }
+        updateState { it.copy(isLoadingPopularity = true, hasPopularityError = false) }
         safeCollect(
             onEmitNewValue = ::onGetPopularityMoviesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingPopularity = false,
+                        hasPopularityError = true
+                    )
+                }
+            },
             block = observePopularMoviesUseCase::invoke
         )
         safeCollect(
             onEmitNewValue = ::onGetPopularitySeriesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingPopularity = false,
+                        hasPopularityError = true
+                    )
+                }
+            },
             block = observePopularSeriesUseCase::invoke
         )
     }
@@ -118,27 +126,38 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun updatePopularityMedia(items: List<PopularMediaUi>) {
-        if (items.isNotEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            delay(5000)
-            updateState { currentState ->
-                currentState.copy(
-                    popularity = (items + currentState.popularity).distinctBy { it.id },
-                    isLoadingPopularity = false
-                )
-            }
+        if (items.isNotEmpty()) updateState {
+            it.copy(
+                popularity = (items + it.popularity).distinctBy { item -> item.id },
+                isLoadingPopularity = false
+            )
         }
     }
 
-    private fun getRecentlyReleased() {
-        updateState { it.copy(isLoadingRecentlyReleased = true) }
+    override fun getRecentlyReleased() {
+        updateState { it.copy(isLoadingRecentlyReleased = true, hasRecentlyReleasedError = false) }
         safeCollect(
             onEmitNewValue = ::onGetRecentlyReleasedMoviesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingRecentlyReleased = false,
+                        hasRecentlyReleasedError = true
+                    )
+                }
+            },
             block = observeRecentlyReleasedMoviesUseCase::invoke
         )
         safeCollect(
             onEmitNewValue = ::onGetRecentlyReleasedSeriesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingRecentlyReleased = false,
+                        hasRecentlyReleasedError = true
+                    )
+                }
+            },
             block = observeRecentlyReleasedSeriesUseCase::invoke
         )
     }
@@ -152,42 +171,42 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun updateRecentlyReleasedPosters(posters: List<Poster>) {
-        viewModelScope.launch(Dispatchers.IO) {
-            delay(5000)
-            updateState { currentState ->
-                currentState.copy(
-                    recentlyReleased = (posters + currentState.recentlyReleased).distinctBy { it.id },
-                    isLoadingRecentlyReleased = false
-                )
-            }
+        if (posters.isNotEmpty()) updateState {
+            it.copy(
+                recentlyReleased = (posters + it.recentlyReleased).distinctBy { item -> item.id },
+                isLoadingRecentlyReleased = false
+            )
         }
     }
 
-    private fun getUpcomingMovies() {
-        updateState { it.copy(isLoadingUpcomingMovies = true) }
+    override fun getUpcoming() {
+        updateState { it.copy(isLoadingUpcoming = true, hasUpcomingError = false) }
         safeCollect(
             onEmitNewValue = ::onGetUpcomingMoviesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingUpcoming = false,
+                        hasUpcomingError = true
+                    )
+                }
+            },
             block = observeUpcomingMoviesUseCase::invoke
         )
     }
 
     private fun onGetUpcomingMoviesSuccess(movies: List<Movie>) {
-        if (movies.isNotEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            delay(5000L)
-            updateState { currentState ->
-                currentState.copy(
-                    upcomingMovies = (movies.map(Movie::toPoster) + currentState.upcomingMovies).distinctBy { it.id },
-                    isLoadingUpcomingMovies = false
-                )
-            }
+        if (movies.isNotEmpty()) updateState {
+            it.copy(
+                upcomingMovies = (movies.map(Movie::toPoster) + it.upcomingMovies).distinctBy { item -> item.id },
+                isLoadingUpcoming = false
+            )
         }
     }
 
     private fun getYourCollections() {
         safeCollect(
             onEmitNewValue = ::onGetYourCollectionsSuccess,
-            onError = ::onError,
             block = getCollectionsUseCase::invoke
         )
     }
@@ -200,37 +219,55 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun getTopRatedSeries() {
-        updateState { it.copy(isLoadingTopRatedSeries = true) }
+    override fun getTopRated() {
+        updateState { it.copy(isLoadingTopRated = true, hasTopRatedError = false) }
         safeCollect(
             onEmitNewValue = ::onGetTopRatedSeriesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingTopRated = false,
+                        hasTopRatedError = true
+                    )
+                }
+            },
             block = observeTopRatedSeriesUseCase::invoke
         )
     }
 
     private fun onGetTopRatedSeriesSuccess(series: List<Series>) {
-        if (series.isNotEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            delay(5000L)
-            updateState { currentState ->
-                currentState.copy(
-                    topRated = (series.map(Series::toPoster) + currentState.topRated).distinctBy { it.id },
-                    isLoadingTopRatedSeries = false
-                )
-            }
+        if (series.isNotEmpty()) updateState {
+            it.copy(
+                topRated = (series.map(Series::toPoster) + it.topRated).distinctBy { item -> item.id },
+                isLoadingTopRated = false
+            )
         }
     }
 
-    private fun getMatchesYourVibe() {
-        updateState { it.copy(isLoadingMatchesYourVibe = true) }
+    override fun getMatchesYourVibe() {
+        updateState { it.copy(isLoadingMatchesYourVibe = true, hasMatchesYourVibeError = false) }
         safeCollect(
             onEmitNewValue = ::onGetMatchesYourVibeMoviesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingMatchesYourVibe = false,
+                        hasMatchesYourVibeError = true
+                    )
+                }
+            },
             block = observeMatchesYourVibeMoviesUseCase::invoke
         )
         safeCollect(
             onEmitNewValue = ::onGetMatchesYourVibeSeriesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingMatchesYourVibe = false,
+                        hasMatchesYourVibeError = true
+                    )
+                }
+            },
             block = observeMatchesYourVibeSeriesUseCase::invoke
         )
     }
@@ -244,27 +281,38 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun updateMatchesYourVibePosters(posters: List<Poster>) {
-        if (posters.isNotEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            delay(5000L)
-            updateState { currentState ->
-                currentState.copy(
-                    matchVibes = (posters + currentState.matchVibes).distinctBy { it.id },
-                    isLoadingMatchesYourVibe = false
-                )
-            }
+        if (posters.isNotEmpty()) updateState {
+            it.copy(
+                matchVibes = (posters + it.matchVibes).distinctBy { item -> item.id },
+                isLoadingMatchesYourVibe = false
+            )
         }
     }
 
-    private fun getRecentlyViewed() {
-        updateState { it.copy(isLoadingRecentlyViewed = true) }
+    override fun getRecentlyViewed() {
+        updateState { it.copy(isLoadingRecentlyViewed = true, hasRecentlyViewedError = false) }
         safeCollect(
             onEmitNewValue = ::onGetRecentlyMoviesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingRecentlyViewed = false,
+                        hasRecentlyViewedError = true
+                    )
+                }
+            },
             block = observeRecentlyViewedMoviesUseCase::invoke
         )
         safeCollect(
             onEmitNewValue = ::onGetRecentlySeriesSuccess,
-            onError = ::onError,
+            onError = {
+                updateState {
+                    it.copy(
+                        isLoadingRecentlyViewed = false,
+                        hasRecentlyViewedError = true
+                    )
+                }
+            },
             block = observeRecentlyViewedSeriesUseCase::invoke
         )
     }
@@ -278,17 +326,14 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun updateRecentPosters(posters: List<Poster>) {
-        if (posters.isNotEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            delay(5000L)
-            updateState {
-                it.copy(
-                    recentlyViewed = (posters + it.recentlyViewed)
-                        .distinctBy { poster -> poster.id }
-                        .sortedByDescending { poster -> poster.recentViewedAt }
-                        .take(20),
-                    isLoadingRecentlyViewed = false
-                )
-            }
+        updateState {
+            it.copy(
+                recentlyViewed = (posters + it.recentlyViewed)
+                    .distinctBy { poster -> poster.id }
+                    .sortedByDescending { poster -> poster.recentViewedAt }
+                    .take(20),
+                isLoadingRecentlyViewed = false
+            )
         }
     }
 
@@ -345,9 +390,5 @@ class HomeViewModel @Inject constructor(
                 sectionType = sectionType
             )
         )
-    }
-
-    private fun onError(error: Throwable) = updateState {
-        it.copy(isNoInternet = error is NoInternetException)
     }
 }

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/utils/Extensions.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/utils/Extensions.kt
@@ -13,13 +13,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
 import com.giraffe.designsystem.theme.Theme
 
 fun Any?.orEmpty(): String = this?.toString() ?: ""
 
-fun Modifier.shimmerEffect() = composed {
+fun Modifier.shimmerEffect(
+    isAnimated: Boolean = true
+) = composed {
     var size by remember { mutableStateOf(IntSize.Zero) }
     val transition = rememberInfiniteTransition()
     val startOffsetX by transition.animateFloat(
@@ -28,7 +31,7 @@ fun Modifier.shimmerEffect() = composed {
         animationSpec = infiniteRepeatable(tween(durationMillis = 1000)),
     )
     background(
-        brush = Brush.linearGradient(
+        brush = if (!isAnimated) SolidColor(Theme.color.shade.quaternary) else Brush.linearGradient(
             colors = listOf(
                 Theme.color.shade.quaternary,
                 Theme.color.shade.shimmer,

--- a/presentation/home/src/main/res/values-ar/strings.xml
+++ b/presentation/home/src/main/res/values-ar/strings.xml
@@ -27,5 +27,6 @@
     <string name="based_on_true_events">بناء على الأحداث الحقيقية</string>
     <string name="feel_good_favorites">المشاعر المفضلة</string>
     <string name="unknown_genre">غير معروف</string>
+    <string name="failed_to_load_the_list">فشل في تحميل القائمة</string>
 
 </resources>

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -30,5 +30,6 @@
     <string name="based_on_true_events">Based on True Events</string>
     <string name="feel_good_favorites">Feel-Good Favorites</string>
     <string name="unknown_genre">Unknown genre</string>
+    <string name="failed_to_load_the_list">Failed to load the list</string>
 
 </resources>

--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/history/HistoryViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/history/HistoryViewModel.kt
@@ -34,12 +34,12 @@ class HistoryViewModel @Inject constructor(
     private fun getGenres() {
         safeCollect(
             onEmitNewValue = ::onGetMoviesGenresSuccess,
-            onError = ::onFailure.also { onGetMoviesGenresFailure() },
+            onError = ::onFailure.also { getRecentViewedMovies() },
             block = observeMoviesGenresUseCase::invoke
         )
         safeCollect(
             onEmitNewValue = ::onGetSeriesGenresSuccess,
-            onError = ::onFailure.also { onGetSeriesGenresFailure() },
+            onError = ::onFailure.also { getRecentViewedSeries() },
             block = observeSeriesGenresUseCase::invoke
         )
     }
@@ -49,16 +49,8 @@ class HistoryViewModel @Inject constructor(
         getRecentViewedMovies()
     }
 
-    private fun onGetMoviesGenresFailure() {
-        getRecentViewedMovies()
-    }
-
     private fun onGetSeriesGenresSuccess(genres: List<Genre>) {
         updateState { it.copy(seriesGenres = genres) }
-        getRecentViewedSeries()
-    }
-
-    private fun onGetSeriesGenresFailure() {
         getRecentViewedSeries()
     }
 

--- a/repository/media/src/main/java/com/giraffe/media/movie/MovieRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/MovieRepositoryImpl.kt
@@ -99,6 +99,7 @@ class MovieRepositoryImpl @Inject constructor(
         return safeFlow {
             movieLocal.getMoviesGenres()
                 .map { it.map(MovieGenreCacheDto::toEntity) }
+                .onEach { it.ifEmpty { getGenres() } }
         }
     }
 
@@ -333,5 +334,4 @@ class MovieRepositoryImpl @Inject constructor(
             movieLocal.clearMatchesYourVibeMovies()
         }
     }
-
 }


### PR DESCRIPTION

- Implemented error handling for different sections in the home screen.
- Added a retry mechanism for failed API calls in the home screen.
- Improved shimmer effect to show non-animated shimmer on error.
- Ensured genres are fetched if the local cache is empty.
- Adjusted debounce time for fetching movie genres.
- Added Arabic translation for "Failed to load the list".
- Refactored HistoryViewModel to simplify error handling for genre fetching.