### PR TITLE
Fix/genres series

### DIFF
--- a/datasource/local/media/src/main/java/com/giraffe/media/series/SeriesLocalDataSourceImp.kt
+++ b/datasource/local/media/src/main/java/com/giraffe/media/series/SeriesLocalDataSourceImp.kt
@@ -11,6 +11,8 @@ import com.giraffe.media.series.mapper.toRecentlyReleasedSeriesCacheDto
 import com.giraffe.media.series.mapper.toTopRatedSeriesCacheDto
 import com.giraffe.media.util.safeCall
 import com.giraffe.media.util.safeFlow
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
 import javax.inject.Inject
 
 class SeriesLocalDataSourceImp @Inject constructor(
@@ -19,8 +21,9 @@ class SeriesLocalDataSourceImp @Inject constructor(
     override suspend fun addSeries(series: SeriesCacheDto) =
         safeCall { seriesDao.upsertSeries(series) }
 
+    @FlowPreview
     override fun getGenres() =
-        safeFlow { seriesDao.getGenres() }
+        safeFlow { seriesDao.getGenres() }.debounce(500L)
 
     override suspend fun syncGenres(genres: List<SeriesGenreCacheDto>) {
         safeCall {

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import com.giraffe.media.movie.usecase.recentlyViewed.ObserveRecentlyViewedMovie
 import com.giraffe.media.movie.usecase.upcoming.ObserveUpcomingMoviesUseCase
 import com.giraffe.media.series.entity.Series
 import com.giraffe.media.series.usecase.ObservePopularSeriesUseCase
+import com.giraffe.media.series.usecase.genre.ObserveSeriesGenresUseCase
 import com.giraffe.media.series.usecase.matchesYourVibe.ObserveMatchesYourVibeSeriesUseCase
 import com.giraffe.media.series.usecase.recentlyReleased.ObserveRecentlyReleasedSeriesUseCase
 import com.giraffe.media.series.usecase.recentlyViewed.ObserveRecentlyViewedSeriesUseCase
@@ -49,13 +50,15 @@ class HomeViewModel @Inject constructor(
     private val getCollectionsUseCase: GetCollectionsUseCase,
     private val getUserNameUseCase: GetUserNameUseCase,
     private val isLoggedInByAccountUseCase: IsLoggedInByAccountUseCase,
-    private val observeMoviesGenresUseCase: ObserveMoviesGenresUseCase
+    private val observeMoviesGenresUseCase: ObserveMoviesGenresUseCase,
+    private val observeSeriesGenresUseCase: ObserveSeriesGenresUseCase
 ) : BaseViewModel<HomeScreenState, HomeEffect>(initialState = HomeScreenState()),
     HomeInteractionListener {
 
     init {
         getUserName()
         getMoviesGenres()
+        getSeriesGenres()
         getRecentlyReleased()
         getUpcomingMovies()
         getYourCollections()
@@ -82,33 +85,50 @@ class HomeViewModel @Inject constructor(
     private fun getMoviesGenres() {
         safeCollect(
             onEmitNewValue = ::onGetMoviesGenresSuccess,
-            onError = ::onError.also { getPopularity() },
+            onError = ::onError.also { getPopularityMovies() },
             block = observeMoviesGenresUseCase::invoke
         )
     }
 
     private fun onGetMoviesGenresSuccess(genres: List<Genre>) {
         updateState { it.copy(moviesGenres = genres) }
-        getPopularity()
+        getPopularityMovies()
     }
 
-    private fun getPopularity() {
+    private fun getSeriesGenres() {
+        safeCollect(
+            onEmitNewValue = ::onGetSeriesGenresSuccess,
+            onError = ::onError.also { getPopularitySeries() },
+            block = observeSeriesGenresUseCase::invoke
+        )
+    }
+
+    private fun onGetSeriesGenresSuccess(genres: List<Genre>) {
+        updateState { it.copy(seriesGenres = genres) }
+        getPopularitySeries()
+    }
+
+    private fun getPopularityMovies() {
         updateState { it.copy(isLoadingPopularity = true) }
         safeCollect(
             onEmitNewValue = ::onGetPopularityMoviesSuccess,
             onError = ::onError,
             block = observePopularMoviesUseCase::invoke
         )
-        safeCollect(
-            onEmitNewValue = ::onGetPopularitySeriesSuccess,
-            onError = ::onError,
-            block = observePopularSeriesUseCase::invoke
-        )
     }
 
     private fun onGetPopularityMoviesSuccess(movies: List<Movie>) {
         val newMovies = movies.map { movie -> movie.toPopularMediaUi(state.value.moviesGenres) }
         updatePopularityMedia(newMovies)
+    }
+
+    private fun getPopularitySeries() {
+        updateState { it.copy(isLoadingPopularity = true) }
+        safeCollect(
+            onEmitNewValue = ::onGetPopularitySeriesSuccess,
+            onError = ::onError,
+            block = observePopularSeriesUseCase::invoke
+        )
     }
 
     private fun onGetPopularitySeriesSuccess(series: List<Series>) {


### PR DESCRIPTION
Debounce genre retrieval in SeriesLocalDataSourceImp

This commit introduces a 500ms debounce to the `getGenres` flow in `SeriesLocalDataSourceImp` to prevent excessive emissions.

Additionally, the `HomeViewModel` has been updated to:
- Fetch series genres alongside movie genres.
- Use the fetched series genres when mapping popular series to `PopularMediaUi`.
- Separate the fetching of popular movies and popular series, ensuring each waits for its respective genre data.