### PR TITLE
Fix recently viewed and search result posters' genres

### DIFF
--- a/presentation/explore/src/main/java/com/giraffe/presentation/explore/screen/searchresult/SearchResultViewModel.kt
+++ b/presentation/explore/src/main/java/com/giraffe/presentation/explore/screen/searchresult/SearchResultViewModel.kt
@@ -98,11 +98,11 @@ class SearchResultViewModel @Inject constructor(
         sendEffect(SearchResultEffect.NavigateBack)
     }
 
-    override fun onPosterClick(id: Int, searchTab: SearchTab) {
-        when (searchTab) {
-            SearchTab.MOVIES -> sendEffect(SearchResultEffect.NavigateToMovieDetail(id))
-            SearchTab.SERIES -> sendEffect(SearchResultEffect.NavigateToSeriesDetail(id))
-            SearchTab.ACTORS -> sendEffect(SearchResultEffect.NavigateToCastDetails(id))
+    override fun onPosterClick(mediaId: Int, selectedTab: SearchTab) {
+        when (selectedTab) {
+            SearchTab.MOVIES -> sendEffect(SearchResultEffect.NavigateToMovieDetail(mediaId))
+            SearchTab.SERIES -> sendEffect(SearchResultEffect.NavigateToSeriesDetail(mediaId))
+            SearchTab.ACTORS -> sendEffect(SearchResultEffect.NavigateToCastDetails(mediaId))
         }
     }
 
@@ -161,18 +161,19 @@ class SearchResultViewModel @Inject constructor(
     }
 
     private fun onGetMoviesSuccess(moviesFlow: Flow<PagingData<Movie>>) {
-        moviesFlow.map { it.map(Movie::toPoster) }.let { posters ->
-            updateState {
-                it.copy(
-                    moviesPosters = posters,
-                    isNoInternet = false,
-                    isLoading = false
-                )
+        moviesFlow.map { it.map { movie -> movie.toPoster(state.value.moviesGenres) } }
+            .let { posters ->
+                updateState {
+                    it.copy(
+                        moviesPosters = posters,
+                        isNoInternet = false,
+                        isLoading = false
+                    )
+                }
+                if (state.value.selectedTab == SearchTab.MOVIES) updateState {
+                    it.copy(selectedPosters = posters)
+                }
             }
-            if (state.value.selectedTab == SearchTab.MOVIES) updateState {
-                it.copy(selectedPosters = posters)
-            }
-        }
     }
 
     private fun getSeries() {
@@ -189,18 +190,19 @@ class SearchResultViewModel @Inject constructor(
     }
 
     private fun onGetSeriesSuccess(seriesFlow: Flow<PagingData<Series>>) {
-        seriesFlow.map { series -> series.map(Series::toPoster) }.let { posters ->
-            updateState {
-                it.copy(
-                    seriesPosters = posters,
-                    isNoInternet = false,
-                    isLoading = false
-                )
+        seriesFlow.map { it.map { series -> series.toPoster(state.value.seriesGenres) } }
+            .let { posters ->
+                updateState {
+                    it.copy(
+                        seriesPosters = posters,
+                        isNoInternet = false,
+                        isLoading = false
+                    )
+                }
+                if (state.value.selectedTab == SearchTab.SERIES) updateState {
+                    it.copy(selectedPosters = posters)
+                }
             }
-            if (state.value.selectedTab == SearchTab.SERIES) updateState {
-                it.copy(selectedPosters = posters)
-            }
-        }
     }
 
     private fun getActors() {
@@ -230,6 +232,7 @@ class SearchResultViewModel @Inject constructor(
             }
         }
     }
+
     private fun observeContentPreference() {
         safeCollect(
             onEmitNewValue = { preference ->
@@ -238,6 +241,7 @@ class SearchResultViewModel @Inject constructor(
             block = getContentPreferenceUseCase::invoke
         )
     }
+
     private fun onError(error: Throwable) {
         updateState {
             it.copy(

--- a/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/giraffe/presentation/home/screen/home/HomeViewModel.kt
@@ -55,8 +55,7 @@ class HomeViewModel @Inject constructor(
     init {
         observeContentPreference()
         getUserName()
-        getMoviesGenres()
-        getSeriesGenres()
+        getGenres()
         getRecentlyReleased()
         getUpcoming()
         getYourCollections()
@@ -79,25 +78,22 @@ class HomeViewModel @Inject constructor(
 
     private fun onGetUseNameSuccess(userName: String) = updateState { it.copy(userName = userName) }
 
-    private fun getMoviesGenres() {
+    private fun getGenres() {
         safeCollect(
             onEmitNewValue = ::onGetMoviesGenresSuccess,
             onError = { getPopularityMovies() },
             block = observeMoviesGenresUseCase::invoke
+        )
+        safeCollect(
+            onEmitNewValue = ::onGetSeriesGenresSuccess,
+            onError = { getPopularitySeries() },
+            block = observeSeriesGenresUseCase::invoke
         )
     }
 
     private fun onGetMoviesGenresSuccess(genres: List<Genre>) {
         updateState { it.copy(moviesGenres = genres) }
         getPopularityMovies()
-    }
-
-    private fun getSeriesGenres() {
-        safeCollect(
-            onEmitNewValue = ::onGetSeriesGenresSuccess,
-            onError = { getPopularitySeries() },
-            block = observeSeriesGenresUseCase::invoke
-        )
     }
 
     private fun onGetSeriesGenresSuccess(genres: List<Genre>) {
@@ -414,6 +410,7 @@ class HomeViewModel @Inject constructor(
             )
         )
     }
+
     private fun observeContentPreference() {
         safeCollect(
             onEmitNewValue = { preference ->

--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/history/HistoryViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/history/HistoryViewModel.kt
@@ -74,11 +74,11 @@ class HistoryViewModel @Inject constructor(
     }
 
     private fun onGetRecentMoviesSuccess(moviesList: List<Movie>) {
-        updateMediaList(moviesList.map { movie -> movie.toPoster(state.value.moviesGenres.filter { it.id in movie.genresID }) })
+        updateMediaList(moviesList.map { movie -> movie.toPoster(state.value.moviesGenres) })
     }
 
     private fun onGetRecentSeriesSuccess(seriesList: List<Series>) {
-        updateMediaList(seriesList.map { series -> series.toPoster(state.value.seriesGenres.filter { it.id in series.genreIDs }) })
+        updateMediaList(seriesList.map { series -> series.toPoster(state.value.seriesGenres) })
     }
 
     private fun updateMediaList(newMediaList: List<Poster>) {
@@ -86,7 +86,7 @@ class HistoryViewModel @Inject constructor(
             it.copy(
                 isLoading = false,
                 isNoInternet = false,
-                mediaList = (it.mediaList + newMediaList)
+                mediaList = (newMediaList + it.mediaList)
                     .distinctBy { poster -> poster.id }
                     .sortedByDescending { poster -> poster.recentViewedAt }
             )

--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/utils/Mapper.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/utils/Mapper.kt
@@ -1,5 +1,6 @@
 package com.giraffe.presentation.profile.utils
 
+import android.util.Log
 import com.giraffe.media.collections.entity.Collection
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.movie.entity.Movie
@@ -25,7 +26,7 @@ fun Series.toRatedPoster(genres: List<Genre>) = RatedPoster(
 fun Series.toPoster(genres: List<Genre> = emptyList()) = Poster(
     id = id,
     name = name,
-    genres = genres.joinToString(", ") { it.title },
+    genres = genres.filter { it.id in genreIDs }.joinToString(", ") { it.title },
     imageUrl = posterUrl,
     rating = rating,
     date = releaseYear.toFormattedDate(),
@@ -38,16 +39,22 @@ fun Movie.toRatedPoster(genres: List<Genre>) = RatedPoster(
     rating = userRating.orZero(),
 )
 
-fun Movie.toPoster(genres: List<Genre> = emptyList()) = Poster(
-    id = id,
-    name = name,
-    genres = genres.joinToString(", ") { it.title },
-    imageUrl = posterUrl,
-    rating = rating,
-    date = releaseYear.toFormattedDate(),
-    mediaTypeOfPoster = "movie",
-    recentViewedAt = recentViewedAt ?: 0L
-)
+fun Movie.toPoster(genres: List<Genre> = emptyList()): Poster {
+    Log.d("modri", "==================movie name: ${this.name}==================")
+    Log.d("modri", "all genres: ${genres.map { it.id }}")
+    Log.d("modri", "movie genres: ${this.genresID}")
+    Log.d("modri", "filtered genres: ${genres.filter { it.id in this.genresID }.map { it.id }}")
+    return Poster(
+        id = id,
+        name = name,
+        genres = genres.filter { it.id in this.genresID }.joinToString(", ") { it.title },
+        imageUrl = posterUrl,
+        rating = rating,
+        date = releaseYear.toFormattedDate(),
+        mediaTypeOfPoster = "movie",
+        recentViewedAt = recentViewedAt ?: 0L
+    )
+}
 
 fun Collection.toUi() = CollectionUi(
     id = id,

--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/utils/Mapper.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/utils/Mapper.kt
@@ -1,6 +1,5 @@
 package com.giraffe.presentation.profile.utils
 
-import android.util.Log
 import com.giraffe.media.collections.entity.Collection
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.movie.entity.Movie
@@ -39,22 +38,16 @@ fun Movie.toRatedPoster(genres: List<Genre>) = RatedPoster(
     rating = userRating.orZero(),
 )
 
-fun Movie.toPoster(genres: List<Genre> = emptyList()): Poster {
-    Log.d("modri", "==================movie name: ${this.name}==================")
-    Log.d("modri", "all genres: ${genres.map { it.id }}")
-    Log.d("modri", "movie genres: ${this.genresID}")
-    Log.d("modri", "filtered genres: ${genres.filter { it.id in this.genresID }.map { it.id }}")
-    return Poster(
-        id = id,
-        name = name,
-        genres = genres.filter { it.id in this.genresID }.joinToString(", ") { it.title },
-        imageUrl = posterUrl,
-        rating = rating,
-        date = releaseYear.toFormattedDate(),
-        mediaTypeOfPoster = "movie",
-        recentViewedAt = recentViewedAt ?: 0L
-    )
-}
+fun Movie.toPoster(genres: List<Genre> = emptyList()) = Poster(
+    id = id,
+    name = name,
+    genres = genres.filter { it.id in this.genresID }.joinToString(", ") { it.title },
+    imageUrl = posterUrl,
+    rating = rating,
+    date = releaseYear.toFormattedDate(),
+    mediaTypeOfPoster = "movie",
+    recentViewedAt = recentViewedAt ?: 0L
+)
 
 fun Collection.toUi() = CollectionUi(
     id = id,

--- a/repository/media/src/main/java/com/giraffe/media/movie/MovieRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/MovieRepositoryImpl.kt
@@ -296,12 +296,8 @@ class MovieRepositoryImpl @Inject constructor(
 
     override suspend fun syncRecentlyViewedMovies() {
         return safeCall {
-            movieLocal.getRecentlyViewedMovieIds().forEach {
-                movieRemote.getMovieById(it)
-                    .toCacheDto()
-                    .also { movie ->
-                        movieLocal.addMovie(movie)
-                    }
+            movieLocal.getRecentlyViewedMovieIds().forEach { movieId ->
+                movieLocal.addMovie(movieRemote.getMovieById(movieId).toCacheDto())
             }
         }
     }

--- a/repository/media/src/main/java/com/giraffe/media/movie/mapper/Mapper.kt
+++ b/repository/media/src/main/java/com/giraffe/media/movie/mapper/Mapper.kt
@@ -109,7 +109,7 @@ fun MovieDto.toCacheDto() = MovieCacheDto(
             BASE_IMAGE_URL + it
     },
     youtubeVideoId = youtubeVideoId,
-    genresID = genresID,
+    genresID = genresID.ifEmpty { genres.map { it.id } },
     releaseYear = releaseDate,
     duration = runtime,
     popularity = popularity.orZero(),

--- a/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
+++ b/repository/media/src/main/java/com/giraffe/media/series/SeriesRepositoryImpl.kt
@@ -137,7 +137,6 @@ class SeriesRepositoryImpl @Inject constructor(
     }
 
     private suspend fun addGenres(genres: List<Genre>) {
-        if (genres.isEmpty()) return
         seriesLocal.syncGenres(genres.map(Genre::toCacheDto))
     }
 


### PR DESCRIPTION
The genres for posters in the recently viewed section and search results were not displaying correctly. This commit fixes the issue by ensuring that the correct genre information is passed and filtered when creating poster objects.

Specifically, the following changes were made:
- Modified `HistoryViewModel` to pass all movie and series genres to the `toPoster` function.
- Updated `SearchResultViewModel` to pass all movie and series genres to the `toPoster` function.
- In `MovieRepositoryImpl`, simplified the logic for syncing recently viewed movies.
- In `Mapper.kt` (movie repository), ensured that `genresID` is populated correctly even if it's initially empty.
- In `SeriesRepositoryImpl`, removed an unnecessary check for empty genres before syncing.
- In `Mapper.kt` (profile presentation), updated `Movie.toPoster` and `Series.toPoster` to correctly filter genres based on the media's genre IDs.
- In `HomeViewModel`, consolidated the fetching of movie and series genres into a single `getGenres` function.

https://github.com/user-attachments/assets/21670ee4-ae40-48de-a024-2db74b33ed8e

