### PR TITLE
Refactor: Reorder modifiers in LoginScreen

### DIFF
--- a/presentation/authentication/src/main/java/com/giraffe/presentation/authentication/screens/login/screen/LoginScreen.kt
+++ b/presentation/authentication/src/main/java/com/giraffe/presentation/authentication/screens/login/screen/LoginScreen.kt
@@ -75,9 +75,9 @@ fun LoginContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(scrollState)
             .background(Theme.color.background.screen)
-            .systemBarsPadding(),
+            .systemBarsPadding()
+            .verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
 


### PR DESCRIPTION
### The `verticalScroll` modifier has been moved after `systemBarsPadding` in the `Column` composable within `LoginScreen`. This ensures that scrolling behavior is applied after system bar padding is accounted for.

### Before:

<img width="744" height="747" alt="image" src="https://github.com/user-attachments/assets/7a7eae58-6b61-44a4-805e-37e086c4f210" />

### After:

<img width="746" height="748" alt="image" src="https://github.com/user-attachments/assets/2e5cc6de-3a1c-45d3-a9d6-5e12276b5115" />
