### PR TITLE
Fix/hidden genre in collection details

### DIFF
--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/collectiondetails/CollectionDetailsViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/collectiondetails/CollectionDetailsViewModel.kt
@@ -30,13 +30,12 @@ class CollectionDetailsViewModel @Inject constructor(
     init {
         observeContentPreference()
         getMoviesGenres()
-        getCollectionItems()
     }
 
     private fun getMoviesGenres() {
         safeCollect(
             onEmitNewValue = ::onGetMoviesGenresSuccess,
-            onError = ::onFailure,
+            onError = ::onFailure.also { getCollectionItems() },
             block = observeMoviesGenresUseCase::invoke
         )
     }
@@ -44,11 +43,11 @@ class CollectionDetailsViewModel @Inject constructor(
     private fun onGetMoviesGenresSuccess(genres: List<Genre>) {
         updateState {
             it.copy(
-                isLoading = false,
                 isNoInternet = false,
                 movieGenres = genres
             )
         }
+        getCollectionItems()
     }
 
     private fun onFailure(error: Throwable, isNoInternet: Boolean) {
@@ -117,6 +116,7 @@ class CollectionDetailsViewModel @Inject constructor(
     override fun onStartCollectingClick() {
         sendEffect(CollectionDetailsEffect.NavigateToExplore)
     }
+
     private fun observeContentPreference() {
         safeCollect(
             onEmitNewValue = { preference ->

--- a/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/collectiondetails/CollectionDetailsViewModel.kt
+++ b/presentation/profile/src/main/java/com/giraffe/presentation/profile/screens/collectiondetails/CollectionDetailsViewModel.kt
@@ -1,12 +1,14 @@
 package com.giraffe.presentation.profile.screens.collectiondetails
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
 import com.giraffe.media.collections.usecase.GetCollectionMoviesUseCase
 import com.giraffe.media.collections.usecase.RemoveMovieFromCollectionUseCase
 import com.giraffe.media.entity.Genre
 import com.giraffe.media.movie.entity.Movie
 import com.giraffe.media.movie.usecase.genre.ObserveMoviesGenresUseCase
 import com.giraffe.presentation.profile.base.BaseViewModel
+import com.giraffe.presentation.profile.navigation.routes.CollectionRoute
 import com.giraffe.presentation.profile.utils.toSwipeablePoster
 import com.giraffe.user.usecase.GetContentPreferenceUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,10 +23,9 @@ class CollectionDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<CollectionDetailsScreenState, CollectionDetailsEffect>(
     CollectionDetailsScreenState(
-        collectionId = savedStateHandle.get<Int>("collectionId") ?: 0,
-        collectionName = savedStateHandle.get<String>("collectionName") ?: "",
-
-        )
+        collectionId = savedStateHandle.toRoute<CollectionRoute>().collectionId,
+        collectionName = savedStateHandle.toRoute<CollectionRoute>().collectionName,
+    )
 ), CollectionDetailsInteractionListener {
 
     init {


### PR DESCRIPTION
### Ensures that collection items are loaded only after the movie genres have been successfully fetched. If fetching genres fails, collection items will still be loaded.

**Before:**

<img width="323" height="720" alt="asxcascascasc" src="https://github.com/user-attachments/assets/772b8e66-2ff1-4034-918e-d10411f67b68" />

**After:**

<img width="336" height="744" alt="image" src="https://github.com/user-attachments/assets/ef13fb57-506c-4a55-8cdf-e158899ccf1e" />
