### PR TITLE
Fix: Prevent unnecessary loading state change in SearchResultViewModel

### DIFF
--- a/presentation/explore/src/main/java/com/giraffe/presentation/explore/screen/searchresult/SearchResultViewModel.kt
+++ b/presentation/explore/src/main/java/com/giraffe/presentation/explore/screen/searchresult/SearchResultViewModel.kt
@@ -83,7 +83,7 @@ class SearchResultViewModel @Inject constructor(
     }
 
     override fun changeView(isGrid: Boolean) {
-        updateState { it.copy(isGridSelected = isGrid, isLoading = true, isNoInternet = false) }
+        updateState { it.copy(isGridSelected = isGrid, isLoading = false) }
     }
 
     override fun onRetryClick() {


### PR DESCRIPTION
Prevent unnecessary loading state change in SearchResultViewModel